### PR TITLE
Get-PnpSiteTemplate - Example for PersistMultiLanguageResources

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-pnp/Get-PnPSiteTemplate.md
+++ b/sharepoint/sharepoint-ps/sharepoint-pnp/Get-PnPSiteTemplate.md
@@ -150,6 +150,15 @@ Get-PnPSiteTemplate -Out template.pnp -ListsToExtract "Title of List One","95c4e
 
 Extracts a provisioning template in Office Open XML from the current web, including only the lists specified by title or ID.
 
+### EXAMPLE 16
+```powershell
+Get-PnPSiteTemplate -Out template.xml -Handlers Fields, ContentTypes, SupportedUILanguages -PersistMultiLanguageResources
+```
+
+Extracts a provisioning template in XML format from the current web including the fields, content types and supported ui languages.
+It will create a resource file for each supported language. The generated resource files will be named 'template.en-US.resx' etc.
+It is mandatory to include the "SupportedUILanguages" in the handlers as otherwise the resource files will not be created.
+
 ## PARAMETERS
 
 ### -Configuration


### PR DESCRIPTION
There was no example for a usage of PersistMultiLanguageResources in combination with handlers.
It is mandatory to add SupportedUILanguages in handlers as otherwise the multilanguage resources do not get exported properly.

Code reference:
https://github.com/pnp/pnpframework/blob/ac4dc39f564fcaa55e140bd7d778149360a265f7/src/lib/PnP.Framework/Provisioning/ObjectHandlers/Extensions/UserResourceExtensions.cs#L92