### PR TITLE
Add AllowMediaTranscription Value

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
@@ -21,7 +21,7 @@ Sets or updates one or more properties' values for a site collection.
 ### ParamSet1
 
 ```powershell
-Set-SPOSite [-Identity] <SpoSitePipeBind> [-AllowSelfServiceUpgrade <Boolean>] [-Confirm]
+Set-SPOSite [-Identity] <SpoSitePipeBind> [-AllowMediaTranscription <Boolean>] [-AllowSelfServiceUpgrade <Boolean>] [-Confirm]
  [-DenyAddAndCustomizePages <Boolean>] [-LocaleId <UInt32>] [-LockState <String>] [-NoWait] [-Owner <String>]
  [-ResourceQuota <Double>] [-ResourceQuotaWarningLevel <Double>]
  [-SandboxedCodeActivationCapability <SandboxedCodeActivationCapabilities>]
@@ -193,6 +193,22 @@ Required: True
 Position: 1
 Default value: None
 Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -AllowMediaTranscription
+
+When the feature is enabled, videos can have transcripts generated on demand or generated automatically in certain scenarios. This is the default because the policy is default on. If a video owner decides they don’t want the transcript, they can always hide or delete it from that video. 
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: True
+Accept pipeline input: False
 Accept wildcard characters: False
 ```
 


### PR DESCRIPTION
Adding guidance for AllowMediaTranscription boolean that controls transcript policy for admins to manage transcription generation for all videos in ODSP.  This will control the initial on demand feature allowing owners to request a transcript on demand as well as the longer term automatic feature which will transcribe more videos automatically in the background.