### PR TITLE
Update to verbiage

### DIFF
--- a/sharepoint/docs-conceptual/sharepoint-pnp/sharepoint-pnp-cmdlets.md
+++ b/sharepoint/docs-conceptual/sharepoint-pnp/sharepoint-pnp-cmdlets.md
@@ -6,7 +6,7 @@ description: "SharePoint PnP PowerShell Overview"
 
 # PnP PowerShell overview
 
-SharePoint Patterns and Practices (PnP) contains a library of PowerShell commands (PnP PowerShell) that allows you to perform complex provisioning and artifact management actions towards SharePoint. The commands use CSOM and can work against both SharePoint Online as SharePoint On-Premises.
+SharePoint Patterns and Practices (PnP) contains a library of PowerShell commands (PnP PowerShell) that allows you to perform complex provisioning and artifact management actions towards SharePoint. The commands uses CSOM and works against SharePoint Online.
 
 ![SharePoint Patterns and Practices](https://devofficecdn.azureedge.net/media/Default/PnP/sppnp.png)
 

--- a/sharepoint/docs-conceptual/sharepoint-pnp/sharepoint-pnp-cmdlets.md
+++ b/sharepoint/docs-conceptual/sharepoint-pnp/sharepoint-pnp-cmdlets.md
@@ -6,7 +6,7 @@ description: "SharePoint PnP PowerShell Overview"
 
 # PnP PowerShell overview
 
-SharePoint Patterns and Practices (PnP) contains a library of PowerShell commands (PnP PowerShell) that allows you to perform complex provisioning and artifact management actions towards SharePoint. The commands uses CSOM and works against SharePoint Online.
+SharePoint Patterns and Practices (PnP) contains a library of PowerShell commands (PnP PowerShell) that allows you to perform complex provisioning and artifact management actions towards SharePoint. The commands use CSOM and work against SharePoint Online.
 
 ![SharePoint Patterns and Practices](https://devofficecdn.azureedge.net/media/Default/PnP/sppnp.png)
 

--- a/sharepoint/docs-conceptual/sharepoint-pnp/sharepoint-pnp-cmdlets.md
+++ b/sharepoint/docs-conceptual/sharepoint-pnp/sharepoint-pnp-cmdlets.md
@@ -6,7 +6,7 @@ description: "SharePoint PnP PowerShell Overview"
 
 # PnP PowerShell overview
 
-SharePoint Patterns and Practices (PnP) contains a library of PowerShell commands (PnP PowerShell) that allows you to perform complex provisioning and artifact management actions towards SharePoint. The commands use CSOM and work against SharePoint Online.
+SharePoint Patterns and Practices (PnP) contains a library of PowerShell commands (PnP PowerShell) that allows you to perform complex provisioning and artifact management actions toward SharePoint. The commands use CSOM and work against SharePoint Online.
 
 ![SharePoint Patterns and Practices](https://devofficecdn.azureedge.net/media/Default/PnP/sppnp.png)
 


### PR DESCRIPTION
[#7734](https://github.com/SharePoint/sp-dev-docs/issues/7734) issue in sp-dev-docs mentions a typo to this. However, we should remove the SharePoint On-Premises description as PnP.PowerShell is not supported on-premises, only the older PnP Powershell Modules are.