### PR TITLE
Fixing the navigation nodes for PnP PowerShell

### DIFF
--- a/sharepoint/docs-conceptual/sharepoint-online/index.yml
+++ b/sharepoint/docs-conceptual/sharepoint-online/index.yml
@@ -61,7 +61,7 @@ landingContent:
           - text: Overview
             url: ../sharepoint-pnp/sharepoint-pnp-cmdlets.md     
           - text: Cmdlet reference
-            url: /powershell/module/sharepoint-pnp
+            url: https://pnp.github.io/powershell/
           - text: PowerShell Gallery
             url: https://www.powershellgallery.com/
 

--- a/sharepoint/docs-conceptual/sharepoint-pnp/index.yml
+++ b/sharepoint/docs-conceptual/sharepoint-pnp/index.yml
@@ -61,7 +61,7 @@ landingContent:
           - text: Overview
             url: sharepoint-pnp-cmdlets.md     
           - text: Cmdlet reference
-            url: /powershell/module/sharepoint-pnp
+            url: https://pnp.github.io/powershell/
           - text: PowerShell Gallery
             url: https://www.powershellgallery.com/
 

--- a/sharepoint/docs-conceptual/sharepoint-server/index.yml
+++ b/sharepoint/docs-conceptual/sharepoint-server/index.yml
@@ -61,7 +61,7 @@ landingContent:
           - text: Overview
             url: ../sharepoint-pnp/sharepoint-pnp-cmdlets.md     
           - text: Cmdlet reference
-            url: /powershell/module/sharepoint-pnp
+            url: https://pnp.github.io/powershell/
           - text: PowerShell Gallery
             url: https://www.powershellgallery.com/
 

--- a/sharepoint/docs-conceptual/toc.yml
+++ b/sharepoint/docs-conceptual/toc.yml
@@ -9,12 +9,12 @@ items:
     href: sharepoint-online/connect-sharepoint-online.md
   - name: Cmdlet reference
     href: /powershell/module/sharepoint-online/?view=sharepoint-ps
-- name: SharePoint PnP
+- name: PnP PowerShell
   items:
   - name: Overview
     href: sharepoint-pnp/sharepoint-pnp-cmdlets.md
   - name: Cmdlet reference
-    href: /powershell/module/sharepoint-pnp/?view=sharepoint-ps
+    href: https://pnp.github.io/powershell/
 - name: SharePoint Server
   href: sharepoint-server/sharepoint-server-cmdlets.md
 


### PR DESCRIPTION
Fixing the navigation nodes in the TOC for PnP PowerShell move - as the community owned module docs are removed from the docs.microsoft.com to avoid confusion on the supportability status. 

PnP PowerShell is intentionally left on the TOC to help to redirect to new location.