### PR TITLE
add default date that maps to initial import

### DIFF
--- a/sharepoint/docfx.json
+++ b/sharepoint/docfx.json
@@ -42,6 +42,7 @@
       "author": "techwriter40",
       "ms.author": "pamgreen",
       "ms.devlang": "powershell",
+      "ms.date": "09/08/2021",
       "ms.prod": "sharepoint-server-itpro",
       "contributors_to_exclude": [ 
         "rjagiewich", 


### PR DESCRIPTION
This does the same thing as adding ms.date to every article. First commit date would usually different for articles but given all articles were moved on the same date, they all have the same first commit.

Articles can override this by adding ms.date directly to their metadata section.