### PR TITLE
Update Enable-SPSessionStateService.md

### DIFF
--- a/sharepoint/sharepoint-server-ps/sharepoint-server/Enable-SPSessionStateService.md
+++ b/sharepoint/sharepoint-server-ps/sharepoint-server/Enable-SPSessionStateService.md
@@ -47,7 +47,7 @@ This example enables a ASP.NET session state on a SharePoint Server farm that us
 
 ### --------------EXAMPLE 2----------------- 
 ```powershell
-Enable-SPSessionStateService -DatabaseName "Session State Database" -DatabaseServer "localhost" -SessionTimeout 120
+Enable-SPSessionStateService -DatabaseName "SessionStateDatabase" -DatabaseServer "localhost" -SessionTimeout 120
 ```
 
 This example enables a ASP.NET session state on a SharePoint Server farm that uses a custom database name, database server, session time-out of 120 minutes, and Windows credentials (due to the lack of a DatabaseCredentials parameter).


### PR DESCRIPTION
Change:  Remove the spaces in the database name of the Session State Database.

The spaces in the database name are the cause for the issue described in   https://social.technet.microsoft.com/Forums/en-US/7e905658-3c2a-49ce-ade0-dcc439c1eab1/scaling-out-an-installation-configuration-on-new-app-server-fails-task-configdb-has-failed-with-an?forum=sharepointgeneralprevious 

The same issue can occur in SharePoint 2013 - SharePoint Subscription Edition. I just got a support case because the customer could not add a new server to a SP 2019 farm.