### PR TITLE
Update Set-SPOTenant.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -2361,7 +2361,7 @@ The valid values are:
 - OwnerModerated
 - Mixed
 
-For more information about information barriers, see [Use information barriers with SharePoint](/purview/information-barriers-sharepoint) for your SharePoint online environment.
+For more information about information barriers, see [Use information barriers with SharePoint](/purview/information-barriers-sharepoint) for your SharePoint Online environment.
   
 ```yaml
 Type: String

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -537,7 +537,7 @@ The valid values are:
 - False - No folder is created when the site and OneDrive for Business document library is created.
 
 The default behavior of the Shared with Everyone folder changed in August 2015.  
-For additional information about the change, see [Provision the Shared with Everyone folder in OneDrive for Business](https://support.office.com/en-us/article/Provision-the-Shared-with-Everyone-folder-in-OneDrive-for-Business-6bb02c91-fd0b-42ba-9457-3921cb6dc5b2?ui=en-US&rs=en-US&ad=US).
+For additional information about the change, see [Provision the Shared with Everyone folder in OneDrive for Business](https://support.office.com/article/Provision-the-Shared-with-Everyone-folder-in-OneDrive-for-Business-6bb02c91-fd0b-42ba-9457-3921cb6dc5b2).
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -2335,7 +2335,7 @@ Accept wildcard characters: False
 
 ### -IBImplicitGroupBased
 
-The IBImplicitGroupBased setting enables Microsoft 365 group-membership based access and sharing control for all Implicit mode sites.
+The IBImplicitGroupBased setting enables Microsoft 365 Groups membership-based access and sharing control for all Implicit mode sites.
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -2319,7 +2319,7 @@ Accept wildcard characters: False
 
 ### -InformationBarriersSuspension
 
-The InformationBarriersSuspension setting enables information barriers in SharePoint and OneDrive when set to $false, or disables information barriers when set to $true.
+When InformationBarriersSuspension parameter is set to $false, information barriers in SharePoint and OneDrive is enabled, when set to $true, it is disabled.
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -113,6 +113,9 @@ Set-SPOTenant [-ApplyAppEnforcedRestrictionsToAdHocRecipients <Boolean>]
  [-ReduceTempTokenLifetimeEnabled <Boolean>]
  [-ReduceTempTokenLifetimeValue <Int32>]
  [-ShowPeoplePickerGroupSuggestionsForIB <Boolean>]
+ [-InformationBarriersSuspension <Boolean>]
+ [-IBImplicitGroupBased <Boolean>]
+ [-DefaultOneDriveInformationBarrierMode <String>]
  [-ViewersCanCommentOnMediaDisabled <Boolean>]
  [-CoreSharingCapability <SharingCapabilities>]
  [-OneDriveRequestFilesLinkEnabled <Boolean>]
@@ -534,7 +537,7 @@ The valid values are:
 - False - No folder is created when the site and OneDrive for Business document library is created.
 
 The default behavior of the Shared with Everyone folder changed in August 2015.  
-For additional information about the change, see Provision the Shared with Everyone folder in OneDrive for Business (<https://support.office.com/en-us/article/Provision-the-Shared-with-Everyone-folder-in-OneDrive-for-Business-6bb02c91-fd0b-42ba-9457-3921cb6dc5b2?ui=en-US&rs=en-US&ad=US)>
+For additional information about the change, see [Provision the Shared with Everyone folder in OneDrive for Business](https://support.office.com/en-us/article/Provision-the-Shared-with-Everyone-folder-in-OneDrive-for-Business-6bb02c91-fd0b-42ba-9457-3921cb6dc5b2?ui=en-US&rs=en-US&ad=US)
 
 ```yaml
 Type: Boolean
@@ -2304,6 +2307,64 @@ The ShowPeoplePickerGroupSuggestionsForIB setting (defaulted to false) allows sh
 
 ```yaml
 Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InformationBarriersSuspension
+
+The InformationBarriersSuspension setting enables information barriers in SharePoint and OneDrive when set to $false, or disables information barriers when set to $true.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IBImplicitGroupBased
+
+The IBImplicitGroupBased setting enables Microsoft 365 group-membership based access and sharing control for all Implicit mode sites.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DefaultOneDriveInformationBarrierMode
+
+The DefaultOneDriveInformationBarrierMode sets the information barrier mode for all OneDrive sites.
+
+The valid values are:
+
+- Open
+- Explicit
+- Implicit
+- OwnerModerated
+- Mixed
+
+For more information about information barriers, see [Use information barriers with SharePoint](https://learn.microsoft.com/en-us/purview/information-barriers-sharepoint) for your SharePoint online environment.
+  
+```yaml
+Type: String
 Parameter Sets: (All)
 Aliases:
 Applicable: SharePoint Online

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -537,7 +537,7 @@ The valid values are:
 - False - No folder is created when the site and OneDrive for Business document library is created.
 
 The default behavior of the Shared with Everyone folder changed in August 2015.  
-For additional information about the change, see [Provision the Shared with Everyone folder in OneDrive for Business](https://support.office.com/en-us/article/Provision-the-Shared-with-Everyone-folder-in-OneDrive-for-Business-6bb02c91-fd0b-42ba-9457-3921cb6dc5b2?ui=en-US&rs=en-US&ad=US)
+For additional information about the change, see [Provision the Shared with Everyone folder in OneDrive for Business](https://support.office.com/en-us/article/Provision-the-Shared-with-Everyone-folder-in-OneDrive-for-Business-6bb02c91-fd0b-42ba-9457-3921cb6dc5b2?ui=en-US&rs=en-US&ad=US).
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -2361,7 +2361,7 @@ The valid values are:
 - OwnerModerated
 - Mixed
 
-For more information about information barriers, see [Use information barriers with SharePoint](https://learn.microsoft.com/en-us/purview/information-barriers-sharepoint) for your SharePoint online environment.
+For more information about information barriers, see [Use information barriers with SharePoint](/purview/information-barriers-sharepoint) for your SharePoint online environment.
   
 ```yaml
 Type: String


### PR DESCRIPTION
Added missing parameters: InformationBarriersSuspension, IBImplicitGroupBased, DefaultOneDriveInformationBarrierMode.

The parameters are already available in the released SharePoint Online Management Shell v 16.0.22810.
The descriptions are based on https://learn.microsoft.com/en-us/purview/information-barriers-sharepoint.