### PR TITLE
Fix breadcrumbs

### DIFF
--- a/sharepoint/breadcrumb/toc.yml
+++ b/sharepoint/breadcrumb/toc.yml
@@ -1,3 +1,3 @@
-- name: Docs
-  tocHref: /
-  topicHref: /
+- name: SharePoint
+  tocHref: /powershell/module/sharepoint-server/
+  topicHref: /sharepoint/index

--- a/sharepoint/breadcrumb/toc.yml
+++ b/sharepoint/breadcrumb/toc.yml
@@ -1,3 +1,13 @@
 - name: SharePoint
-  tocHref: /powershell/module/sharepoint-server/
+  tocHref: /powershell/module/
   topicHref: /sharepoint/index
+  items:
+  - name: SharePoint PowerShell
+    tocHref: /powershell/module/sharepoint-server/
+    topicHref: /powershell/sharepoint/index
+- name: SharePoint
+  tocHref: /powershell/sharepoint/
+  topicHref: /sharepoint/index
+  - name: SharePoint PowerShell
+    tocHref: /powershell/sharepoint/
+    topicHref: /powershell/sharepoint/index

--- a/sharepoint/docfx.json
+++ b/sharepoint/docfx.json
@@ -36,7 +36,6 @@
       "ms.service": "sharepoint-server-itpro",
       "uhfHeaderId": "MSDocsHeader-M365-IT",
       "breadcrumb_path": "/sharepoint/breadcrumb/toc.json",
-      "extendBreadcrumb": true,
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/OfficeDocs-SharePoint-powershell",
       "feedback_product_url": "https://github.com/MicrosoftDocs/OfficeDocs-SharePoint-powershell/issues",

--- a/sharepoint/docfx.json
+++ b/sharepoint/docfx.json
@@ -35,7 +35,7 @@
     "globalMetadata": {
       "ms.service": "sharepoint-server-itpro",
       "uhfHeaderId": "MSDocsHeader-M365-IT",
-      "breadcrumb_path": "/sharepoint/breadcrumb/toc.json",
+      "breadcrumb_path": "/powershell/breadcrumb/toc.json",
       "feedback_system": "GitHub",
       "feedback_github_repo": "MicrosoftDocs/OfficeDocs-SharePoint-powershell",
       "feedback_product_url": "https://github.com/MicrosoftDocs/OfficeDocs-SharePoint-powershell/issues",


### PR DESCRIPTION
This PR brings breadcrumb implementation into alignment with [platform architecture requirements](https://review.learn.microsoft.com/en-us/help/platform/navigation-overview?branch=main#requirements-for-content-ecosystems). This PR is part of a previously announced batch of breadcrumb fixes across the Learn platform and will be auto-merged if there are no build warnings. This PR may include removing the “extend breadcrumb” feature from any docfx files that are still using it, fixing breadcrumb file references in the docfx file, and rewriting breadcrumb files to match the [approved breadcrumb pattern](https://review.learn.microsoft.com/en-us/help/platform/navigation-breadcrumbs-overview?branch=main#breadcrumbs-in-documentation) for a given product’s documentation. 