### PR TITLE
remove ShowOpenInDesktopOptionForSyncedFiles from documentation

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -2285,26 +2285,6 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -ShowOpenInDesktopOptionForSyncedFiles
-
-The ShowOpenInDesktopOptionForSyncedFiles setting (set to false by default) displays the "Open in desktop" option when users go to SharePoint or OneDrive on the web and open the shortcut menu for a file that they're syncing with the OneDrive sync app.
-
-The valid values are:
-
-- False (default) – "Open in desktop" is disabled and not shown on the shortcut menu.
-- True – "Open in desktop" is enabled and the option to open synced files locally appears on the shortcut menu.
-
-```yaml
-Type: Boolean
-Parameter Sets: (All)
-Aliases:
-Required: False
-Position: Named
-Default value: False
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
 ### -OneDriveLoopDefaultSharingLinkScope
 
 Gets or sets default share link scope for Loop and Whiteboard files on OneDrive sites. 


### PR DESCRIPTION
The feature is fully flighted and we no long wish to provide tenants the ability to turn it off. Moreover the web flight are bypassing the setting set by this cmdlet so it doesn't work no longer. Removing from documentation.