### PR TITLE
Remove ms.topic, which is defined in docfx.json

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOListDesign.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOListDesign.md
@@ -6,7 +6,6 @@ schema: 2.0.0
 author: reedpamsft
 ms.author: reedpa
 ms.reviewer:
-ms.topic: List Templates
 title: Add-SPOListDesign
 ---
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantRenameSitePrioritization.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantRenameSitePrioritization.md
@@ -9,7 +9,7 @@ ms.author: anfra
 ms.reviewer: anushmag
 manager: anushmag
 schema: 2.0.0
-ms.topic: reference
+
 ---
 
 # Get-SPOTenantRenameSitePrioritization

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantRenameSitePrioritization.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOTenantRenameSitePrioritization.md
@@ -9,7 +9,7 @@ ms.author: anfra
 ms.reviewer: anushmag
 manager: anushmag
 schema: 2.0.0
-ms.topic: reference
+
 ---
 
 # Remove-SPOTenantRenameSitePrioritization

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantRenameSitePrioritization.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantRenameSitePrioritization.md
@@ -9,7 +9,7 @@ ms.author: anfra
 ms.reviewer: anushmag
 manager: anushmag
 schema: 2.0.0
-ms.topic: reference
+
 ---
 
 # Set-SPOTenantRenameSitePrioritization


### PR DESCRIPTION
This PR resolves ms-topic-invalid in [sharepoint/sharepoint-ps/sharepoint-online/Add-SPOListDesign.md](https://github.com/czhao2009/OfficeDocs-SharePoint-PowerShell/blob/patch-2/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOListDesign.md) and removes **ms.topic** from other articles in the repo, because the value ("reference") is defined in docfx.json.