### PR TITLE
Update SPOContentSecurityPolicy cmdlets

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOContentSecurityPolicy.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOContentSecurityPolicy.md
@@ -55,3 +55,5 @@ Accept wildcard characters: False
 [Get-SPOContentSecurityPolicy](Get-SPOContentSecurityPolicy.md)
 
 [Remove-SPOContentSecurityPolicy](Remove-SPOContentSecurityPolicy.md)
+
+[Content Security Policy source values](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOContentSecurityPolicy.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Add-SPOContentSecurityPolicy.md
@@ -15,46 +15,27 @@ ms.reviewer:
 
 ## SYNOPSIS
 
-Adds an entry to the **Content Security Policy** configuration.
+Adds a source to the **Content Security Policy** configuration.
 
 ## SYNTAX
 
 ### Default
 
 ```powershell
-Add-SPOContentSecurityPolicy [-Url] <String> [-Directive] <String> 
+Add-SPOContentSecurityPolicy [-Source] <String>
 ```
 
 ## DESCRIPTION
 
-Adds an entry to the **Content Security Policy** configuration. 
-The url in each entry will be added to the corresponding directive during construction of the Content-Security-Policy header.
-In multi-geo environments **Content Security Policy** entries are unique to each geo.
-Entries with a "*" directive will be applied to all directives.
+Adds a source to the **Content Security Policy** configuration. 
+The source will be added to the `script-src` directive during construction of the `Content-Security-Policy` header.
+In multi-geo environments, **Content Security Policy** configuration is unique to each geo.
 
 ## PARAMETERS
 
-### -Url
+### -Source
 
-Url to allow as part of this **Content Security Policy** entry.
-
-```yaml
-Type: String
-Parameter Sets: (All)
-Aliases:
-Applicable: SharePoint Online
-
-Required: True
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Directive
-
-Directive to allow as part of this **Content Security Policy** entry.
-Currently allowed values are "*", "script-src" and "worker-src".
+Source to be added to the **Content Security Policy** configuration.
 
 ```yaml
 Type: String
@@ -63,7 +44,7 @@ Aliases:
 Applicable: SharePoint Online
 
 Required: True
-Position: Named
+Position: 0
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOContentSecurityPolicy.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOContentSecurityPolicy.md
@@ -15,7 +15,7 @@ ms.reviewer:
 
 ## SYNOPSIS
 
-Returns all entries in the current **Content Security Policy** configuration.
+Returns all sources in the current **Content Security Policy** configuration.
 
 ## SYNTAX
 
@@ -27,8 +27,8 @@ Get-SPOContentSecurityPolicy
 
 ## DESCRIPTION
 
-Returns all entries in the current **Content Security Policy** configuration.
-The url in each entry will be added to the corresponding directive during construction of the `Content-Security-Policy` header.
+Returns all sources in the current **Content Security Policy** configuration.
+Each source will be added to the `script-src` directive during construction of the `Content-Security-Policy` header.
 
 ## RELATED LINKS
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOContentSecurityPolicy.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOContentSecurityPolicy.md
@@ -34,3 +34,5 @@ Returns all sources in the current **Content Security Policy** configuration.
 [Add-SPOContentSecurityPolicy](Add-SPOContentSecurityPolicy.md)
 
 [Remove-SPOContentSecurityPolicy](Remove-SPOContentSecurityPolicy.md)
+
+[Content Security Policy source values](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOContentSecurityPolicy.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOContentSecurityPolicy.md
@@ -28,7 +28,6 @@ Get-SPOContentSecurityPolicy
 ## DESCRIPTION
 
 Returns all sources in the current **Content Security Policy** configuration.
-Each source will be added to the `script-src` directive during construction of the `Content-Security-Policy` header.
 
 ## RELATED LINKS
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOContentSecurityPolicy.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOContentSecurityPolicy.md
@@ -15,26 +15,26 @@ ms.reviewer:
 
 ## SYNOPSIS
 
-Removes entries from the **Content Security Policy** configuration.
+Removes a source from the **Content Security Policy** configuration.
 
 ## SYNTAX
 
 ### Default
 
 ```powershell
-Remove-SPOContentSecurityPolicy [-Url] <String>
+Remove-SPOContentSecurityPolicy [-Source] <String>
 ```
 
 ## DESCRIPTION
 
-Removes all entries associated with the given url from the **Content Security Policy** configuration. 
-In multi-geo environments, **Content Security Policy** entries are unique to each geo.
+Removes the given source from the **Content Security Policy** configuration. 
+In multi-geo environments, **Content Security Policy** configuration is unique to each geo.
 
 ## PARAMETERS
 
-### -Url
+### -Source
 
-Url of the **Content Security Policy** entries to be removed.
+Source to be removed from the **Content Security Policy** configuration.
 
 ```yaml
 Type: String

--- a/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOContentSecurityPolicy.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Remove-SPOContentSecurityPolicy.md
@@ -54,3 +54,5 @@ Accept wildcard characters: False
 [Get-SPOContentSecurityPolicy](Get-SPOContentSecurityPolicy.md)
 
 [Add-SPOContentSecurityPolicy](Add-SPOContentSecurityPolicy.md)
+
+[Content Security Policy source values](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/Sources#sources)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -3011,8 +3011,8 @@ Accept wildcard characters: False
 
 ### -ResyncContentSecurityPolicyConfigurationEntries
 
-When set to `True`, forces a sync of **Content Security Policy** entries for SharePoint framework component in the tenant application catalog.
-New entries will be added to the configuration, if not already present, based on the `cdnBasedPath` property under a solution's `.config/write-manifests.json` if present.
+When set to `True`, forces a sync of **Content Security Policy** sources for SharePoint Framework components in the tenant application catalog.
+New sources will be added to the configuration, if not already present, based on the `cdnBasedPath` property under a solution's `.config/write-manifests.json` if present.
 The sync may take up to 24 hours to complete.
 In multi-geo environments, **Content Security Policy** configuration is unique to each geo.
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -3029,7 +3029,7 @@ Accept wildcard characters: False
 
 ### -EnforceContentSecurityPolicyConfiguration
 
-When set to `True`, opts-in to enforcement of the current **Content Security Policy** configuration.
+When set to `True` **Content Security Policy** violations will be enforced.
 In multi-geo environments, **Content Security Policy** configuration is unique to each geo.
 
 ```yaml

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -156,7 +156,8 @@ Set-SPOTenant
  [-CoreDefaultLinkToExistingAccess <Boolean>]
  [-SelfServiceSiteCreationDisabled <Boolean>]
  [-SyncAadB2BManagementPolicy <Boolean>]
- [-ContentSecurityPolicyConfigSynced <Boolean>]
+ [-ResyncContentSecurityPolicyConfigurationEntries <Boolean>]
+ [-EnforceContentSecurityPolicy <Boolean>]
  [-DocumentUnderstandingModelScope <SyntexFeatureScopeValue>]
  [-DocumentUnderstandingModelSelectedSitesList [String[]]]
  [-DocumentUnderstandingModelSelectedSitesListOperation <SelectedSitesListOperations>]
@@ -3013,7 +3014,23 @@ Accept wildcard characters: False
 When set to `True`, forces a sync of **Content Security Policy** entries for SharePoint framework component in the tenant application catalog.
 New entries will be added to the configuration, if not already present, based on the `cdnBasedPath` property under a solution's `.config/write-manifests.json` if present.
 The sync may take up to 24 hours to complete.
-In multi-geo environments, **Content Security Policy** entries are unique to each geo.
+In multi-geo environments, **Content Security Policy** configuration is unique to each geo.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnforceContentSecurityPolicyConfiguration
+
+When set to `True`, opts-in to enforcement of the current **Content Security Policy** configuration.
+In multi-geo environments, **Content Security Policy** configuration is unique to each geo.
 
 ```yaml
 Type: Boolean


### PR DESCRIPTION
Simplify API by removing references to directive.
Unify terminology by preferring "source" over "url".
Add additional tenant flag for early opt-in to enforcement.