### PR TITLE
Update Set-SPOTenant.md

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -320,7 +320,7 @@ This example enables users to share with all external collaborators except for t
 Set-SPOTenant -EnableVersionExpirationSetting $true
 ```
 The `EnableVersionExpirationSetting` parameter is no longer active, this feature is now automatically enabled for each tenant. Setting `EnableVersionExpirationSetting` to false would not disable the feature.
-Learn more about the Version History Setting at https://learn.microsoft.com/en-us/sharepoint/document-library-version-history-limits
+[Learn more about Version History Settings](https://learn.microsoft.com/sharepoint/document-library-version-history-limits)
 
 
 ### EXAMPLE 17
@@ -2857,7 +2857,7 @@ Accept wildcard characters: False
 
 ### -EnableVersionExpirationSetting
 The `EnableVersionExpirationSetting` parameter is no longer active, this feature is now automatically enabled for each tenant. 
-Learn more about the Version History Setting at https://learn.microsoft.com/en-us/sharepoint/document-library-version-history-limits
+[Learn more about Version History Settings](https://learn.microsoft.com/sharepoint/document-library-version-history-limits)
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -319,12 +319,9 @@ This example enables users to share with all external collaborators except for t
 ```powershell
 Set-SPOTenant -EnableVersionExpirationSetting $true
 ```
+The `EnableVersionExpirationSetting` parameter is no longer active, this feature is now automatically enabled for each tenant. Setting `EnableVersionExpirationSetting` to false would not disable the feature.
+Learn more about the Version History Setting at https://learn.microsoft.com/en-us/sharepoint/document-library-version-history-limits
 
-This example opts your tenant into public preview of Improved Version History controls feature. This feature is being tracked on the Microsoft 365 Public Roadmap under ID [145802](https://www.microsoft.com/en-us/microsoft-365/roadmap?filters=&searchterms=145802).
-
-Visit [http://aka.ms/versioning-overview](http://aka.ms/versioning-overview) to learn more about Admin configurations available to manage versions.
-
-By opting in, you are accepting the terms of service for version history limits. [Read the terms of service](https://aka.ms/versioning-termsofservice).
 
 ### EXAMPLE 17
 
@@ -2859,15 +2856,8 @@ Accept wildcard characters: False
 ```
 
 ### -EnableVersionExpirationSetting
-
-Use the `EnableVersionExpirationSetting` parameter to opt your tenant into public preview of Improved Version History controls feature Microsoft 365 Public Roadmap under ID [145802](https://www.microsoft.com/en-us/microsoft-365/roadmap?filters=&searchterms=145802).
-
-The valid values are:
-
-- True - When set to true and feature roll out to your tenant has completed, admin version history controls at organization, site and library levels will be available.
-- False (default) - When set to false, the feature will be disabled for your tenant.
-
-Note: Disabling the feature after previously enabling it, does not revert changes made when the feature was enabled.
+The `EnableVersionExpirationSetting` parameter is no longer active, this feature is now automatically enabled for each tenant. 
+Learn more about the Version History Setting at https://learn.microsoft.com/en-us/sharepoint/document-library-version-history-limits
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -320,7 +320,7 @@ This example enables users to share with all external collaborators except for t
 Set-SPOTenant -EnableVersionExpirationSetting $true
 ```
 The `EnableVersionExpirationSetting` parameter is no longer active, this feature is now automatically enabled for each tenant. Setting `EnableVersionExpirationSetting` to false would not disable the feature.
-[Learn more about Version History Settings](https://learn.microsoft.com/sharepoint/document-library-version-history-limits)
+[Learn more about Version History Settings](/sharepoint/document-library-version-history-limits)
 
 
 ### EXAMPLE 17
@@ -2857,7 +2857,7 @@ Accept wildcard characters: False
 
 ### -EnableVersionExpirationSetting
 The `EnableVersionExpirationSetting` parameter is no longer active, this feature is now automatically enabled for each tenant. 
-[Learn more about Version History Settings](https://learn.microsoft.com/sharepoint/document-library-version-history-limits)
+[Learn more about Version History Settings](/sharepoint/document-library-version-history-limits)
 
 ```yaml
 Type: Boolean


### PR DESCRIPTION
EnableVersionExpirationSetting parameter is now disabled but not removed, since the Version History Policy is generally available for all tenants (automatically enabled featured)