### PR TITLE
Update documentation of Set-SPOTenant and Set-SPOSite cmdlet

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
@@ -68,11 +68,11 @@ Set-SPOSite [-Identity] <SpoSitePipeBind> [-AllowSelfServiceUpgrade <Boolean>] [
  [-RestrictedAccessControlGroups <Guid>]
  [-RemoveRestrictedAccessControlGroups <Guid>]
  [-ReadOnlyForUnmanagedDevices <Boolean>]
- [-ExcludedBlockDownloadGroupIds <GUID[]>]
+ [-ExcludedBlockDownloadGroupIds <Guid[]>]
  [-ExcludeBlockDownloadPolicySiteOwners <Boolean>]
  [-ReadOnlyForBlockDownloadPolicy <Boolean>]
  [-AuthenticationContextAccessType <SPOAuthenticationContextPolicyAccessType>]
- [-HubSiteId <Guid[]>]
+ [-HubSiteId <Guid>]
  [-InformationBarriersMode <String>]
  [-RestrictContentOrgWideSearch <Boolean>]
  [-RestrictedAccessControl <Boolean>]
@@ -767,7 +767,7 @@ Disables or enables the Social Bar for Site Collection.
 
 The Social Bar will appear on all modern SharePoint pages with the exception of the home page of a site. It will give users the ability to like a page, see the number of views, likes, and comments on a page, and see the people who have liked a page.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 ```yaml
 Type: Boolean
@@ -983,7 +983,7 @@ Accept wildcard characters: False
 
 When set to TRUE, the DefaultSharingLinkType will be overriden and the default sharing link will a People with Existing Access link (which does not modify permissions). When set to FALSE (the default), the DefaultSharingLinkType parameter controls the default sharing link type.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 
 ```yaml
@@ -1227,7 +1227,7 @@ Accept wildcard characters: False
 
 Prevents users from editing Office files in the browser and copying and pasting Office file contents out of the browser window.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 ```yaml
 Type: Boolean
@@ -1307,7 +1307,7 @@ As a SharePoint administrator in Microsoft 365, you can block the download of fi
 
 Blocking the download of files allows users to remain productive while addressing the risk of accidental data loss. Users have browser-only access with no ability to download, print, or sync files. They also won't be able to access content through apps, including the Microsoft Office desktop apps. When web access is limited, users will see the following message at the top of sites: "Your organization doesn't allow you to download, print, or sync from this site. For help contact your IT department." Read the full documentation for advanced capabilities at [Block download policy for SharePoint sites and OneDrive](https://learn.microsoft.com/sharepoint/block-download-from-sites).
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 ```yaml
 Type: Boolean
@@ -1366,7 +1366,7 @@ The valid values are:
 > c. `ExpireVersionsAfterDays` accepts values of 0 to Never Expire or values >= 30 to delete versions that exceed that time period.
 > When version history limits are managed automatically (`EnableAutoExpirationVersionTrim $true`), setting `MajorVersionLimit` or `ExpireVersionsAfterDays` will result in an error as the count limits are set by the service.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 ```yaml
 Type: Boolean
@@ -1597,7 +1597,7 @@ Accept wildcard characters: False
 
 Controls whether unmanaged devices have read-only access.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 ```yaml
 Type: Boolean
@@ -1630,7 +1630,7 @@ Accept wildcard characters: False
 
 Controls if site owners are excluded from block download policy.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 ```yaml
 Type: Boolean
@@ -1647,7 +1647,7 @@ Accept wildcard characters: False
 ### -ReadOnlyForBlockDownloadPolicy
 Controls if read-only should be enabled for block download policy.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 ```yaml
 Type: Boolean
@@ -1701,7 +1701,7 @@ Accept wildcard characters: False
 
 ### -HubSiteId
 
-Sets the hub site for a specified sharepoint site.
+Sets the hub site for a specified SharePoint site.
 
 ```yaml
 Type: GUID
@@ -1735,7 +1735,7 @@ Accept wildcard characters: False
 
 Controls whether org-wide content search is enabled for a site.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 ```yaml
 Type: Boolean
@@ -1753,7 +1753,7 @@ Accept wildcard characters: False
 
 Sets access restriction policy by group membership.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: False | True
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
@@ -67,6 +67,19 @@ Set-SPOSite [-Identity] <SpoSitePipeBind> [-AllowSelfServiceUpgrade <Boolean>] [
  [-RestrictedAccessControl <Boolean>]
  [-RestrictedAccessControlGroups <Guid>]
  [-RemoveRestrictedAccessControlGroups <Guid>]
+ [-ReadOnlyForUnmanagedDevices <Boolean>]
+ [-ExcludedBlockDownloadGroupIds <GUID[]>]
+ [-ExcludeBlockDownloadPolicySiteOwners <Boolean>]
+ [-ReadOnlyForBlockDownloadPolicy <Boolean>]
+ [-AuthenticationContextAccessType <SPOAuthenticationContextPolicyAccessType>]
+ [-HubSiteId <Guid[]>]
+ [-InformationBarriersMode <String>]
+ [-RestrictContentOrgWideSearch <Boolean>]
+ [-RestrictedAccessControl <Boolean>]
+ [-RestrictedAccessControlGroups <Guid[]>]
+ [-AddRestrictedAccessControlGroups <Guid[]>]
+ [-RemoveRestrictedAccessControlGroups <Guid[]>]
+ [-ClearRestrictedAccessControl <SwitchParameter>]
  [<CommonParameters>]
 ```
 
@@ -1580,7 +1593,244 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+### -ReadOnlyForUnmanagedDevices
 
+Controls whether unmanaged devices have read-only access.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludedBlockDownloadGroupIds
+
+Exempts users from specified groups from the block download policy and they can fully download any content for the site.
+
+```yaml
+Type: Guid[] 
+Parameter Sets: (All) 
+Aliases: 
+Applicable: SharePoint Online 
+Required: False 
+Position: Named 
+Default value: None 
+Accept pipeline input: False 
+Accept wildcard characters: False 
+``` 
+
+### -ExcludeBlockDownloadPolicySiteOwners
+
+Controls if site owners are excluded from block download policy.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: ParamSet1
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ReadOnlyForBlockDownloadPolicy
+Controls if read-only should be enabled for block download policy.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: ParamSet1
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludeBlockDownloadSharePointGroups
+
+Specifies the groups excluded from the block download policy.
+
+```yaml
+Type: String
+Parameter Sets: ParamSet1
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AuthenticationContextAccessType
+
+Controls whether Authentication Context Limited Access is enabled for a site.
+
+
+The valid values are:
+
+- AllowLimitedAccess
+- BlockAccess
+
+```yaml
+Type: SPOAuthenticationContextPolicyAccessType
+Parameter Sets: ParamSet1
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HubSiteId
+
+Sets the hub site for a specified sharepoint site.
+
+```yaml
+Type: GUID
+Parameter Sets: ParamSet1
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InformationBarriersMode
+
+Specifies the information barrier mode.
+
+```yaml
+Type: String
+Parameter Sets: ParamSet1
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RestrictContentOrgWideSearch
+
+Controls whether org-wide content search is enabled for a site.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: ParamSet1
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RestrictedAccessControl
+
+Sets access restriction policy by group membership.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: ParamSet1
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RestrictedAccessControlGroups
+
+Specifies the IDs of groups that have access under an access restriction policy.
+
+```yaml
+Type: Guid[] 
+Parameter Sets: (All) 
+Aliases: 
+Applicable: SharePoint Online 
+Required: False 
+Position: Named 
+Default value: None 
+Accept pipeline input: False 
+Accept wildcard characters: False 
+``` 
+
+### -AddRestrictedAccessControlGroups
+
+Specifies the IDs of groups to be added to an access restriction policy and gain access.
+
+```yaml
+Type: Guid[] 
+Parameter Sets: (All) 
+Aliases: 
+Applicable: SharePoint Online 
+Required: False 
+Position: Named 
+Default value: None 
+Accept pipeline input: False 
+Accept wildcard characters: False 
+``` 
+
+### -RemoveRestrictedAccessControlGroups
+
+Specifies the IDs of groups to be removed from access restriction policy and lose access.
+
+```yaml
+Type: Guid[] 
+Parameter Sets: (All) 
+Aliases: 
+Applicable: SharePoint Online 
+Required: False 
+Position: Named 
+Default value: None 
+Accept pipeline input: False 
+Accept wildcard characters: False 
+``` 
+
+### -ClearRestrictedAccessControl
+
+Clears the list of groups that are given access via an access restriction policy.
+
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 ### CommonParameters
 
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
@@ -68,7 +68,7 @@ Set-SPOSite [-Identity] <SpoSitePipeBind> [-AllowSelfServiceUpgrade <Boolean>] [
  [-RestrictedAccessControlGroups <Guid>]
  [-RemoveRestrictedAccessControlGroups <Guid>]
  [-ReadOnlyForUnmanagedDevices <Boolean>]
- [-ExcludedBlockDownloadGroupIds <Guid[]>]
+ [-ExcludedBlockDownloadGroupIds <Guid>]
  [-ExcludeBlockDownloadPolicySiteOwners <Boolean>]
  [-ReadOnlyForBlockDownloadPolicy <Boolean>]
  [-AuthenticationContextAccessType <SPOAuthenticationContextPolicyAccessType>]

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -184,6 +184,32 @@ Set-SPOTenant
  [-WhoCanShareAnonymousAllowList [Guid[]]]
  [-WhoCanShareAuthenticatedGuestAllowList [Guid[]]]
  [-ExtendPermissionsToUnprotectedFiles <Boolean>]
+ [-LegacyBrowserAuthProtocolsEnabled <Boolean>]
+ [-EnableDiscoverableByOrganizationForVideos <Boolean> ]
+ [-RestrictedAccessControlforSitesErrorHelpLink <String> ]
+ [-SensitivityLabel <String> ]
+ [-DisableWorkflow2010 <Boolean> ]
+ [-Sites <String> ]
+ [-AnyoneLinkTrackUsers <Boolean> ]
+ [-OneDriveBlockGuestsAsSiteAdmin <SharingState> ]
+ [-AllowSharingOutsideRestrictedAccessControlGroups <Boolean> ]
+ [-Workflows2013Enabled <Boolean> ]
+ [-IsCollabMeetingNotesFluidEnabled <Boolean> ]
+ [-IsLoopEnabled <Boolean> ]
+ [-DisablePersonalListCreation <Boolean> ]
+ [-DisableVivaConnectionsAnalytics <Boolean> ]
+ [-AppBypassInformationBarriers <Boolean> ]
+ [-DisableModernListTemplateIds <Guid[]> ]
+ [-EnableModernListTemplateIds <Guid[]> ]
+ [-HideSyncButtonOnTeamSite <Boolean> ]
+ [-StreamLaunchConfig <Int32> ]
+ [-EnableRestrictedAccessControl <Boolean> ]
+ [-BlockDownloadFileTypeIds <SPBlockDownloadFileTypeId[]> ]
+ [-ExcludedBlockDownloadGroupIds <GUID[]> ]
+ [-RecycleBinRetentionPeriod <Int32> ]
+ [-EnableMediaReactions <Boolean> ]
+ [-AllowSensitivityLabelOnRecords <Boolean> ]
+ [-ContentSecurityPolicyEnforcement <Boolean> ]
  [<CommonParameters>]
 ```
 
@@ -3621,6 +3647,456 @@ Accept wildcard characters: False
 ``` 
 ### -ExtendPermissionsToUnprotectedFiles
 This property can be used to turn on/off the capability called "Extended SharePoint permissions to unprotected files". To learn more about this feature check [here](https://aka.ms/ExtendSharePointPermission)
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+### -LegacyBrowserAuthProtocolsEnabled
+
+Controls whether legacy browser authentication protocols are enabled.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableDiscoverableByOrganizationForVideos
+
+Allows the sharing dialog to include a checkbox offering the user the ability to share to a security group containing every user in the organization.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RestrictedAccessControlforSitesErrorHelpLink
+
+Sets a custom learn more link to inform users who were denied access to a SharePoint site due to the restricted site access control policy.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SensitivityLabel
+
+Sets the sensitiviy label for a site.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableWorkflow2010
+
+Controls whether Workflow 2010 is enabled.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Sites
+
+List of sites that certain properties will apply to, such as a conditional access policy.
+
+The valid values are:  
+
+- Url
+- SiteId
+
+```yaml
+Type: SpoSitePipeBind
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: Uninitialized
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AnyoneLinkTrackUsers
+
+Requires recipients to verify their identity with an email address to access content from an Anyone link
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OneDriveBlockGuestsAsSiteAdmin
+
+Controls whether guests are blocked from using OneDrive.
+
+The valid values are:
+
+- On
+- Off
+- Unspecified
+
+```yaml
+Type: SharingState
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowSharingOutsideRestrictedAccessControlGroups
+
+Controls whether sharing SharePoint sites and their content is allowed with users and groups who are not allowed as per the Restricted access control policy.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Workflows2013Enabled
+
+Controls whether Workflow 2013 is enabled.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsCollabMeetingNotesFluidEnabled
+
+Controls whether collaborative meeting notes are enabled in Microsoft Teams.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsLoopEnabled
+
+Controls whether Loop components are available in Microsoft Teams. 
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisablePersonalListCreation
+
+Controls whether users can create a personal list.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableVivaConnectionsAnalytics
+
+Controls whether the Viva Connections analytics feature is enabled.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AppBypassInformationBarriers
+
+Controls whether applications running in app-only mode can access sites protected by information barriers.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableModernListTemplateIds
+
+Specifies list of modern template IDs not enabled in tenant.
+
+To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [Get-SPOTenant](Get-SPOTenant.md). 
+
+```yaml
+Type: Guid[] 
+Parameter Sets: (All) 
+Aliases: 
+Applicable: SharePoint Online 
+Required: False 
+Position: Named 
+Default value: None 
+Accept pipeline input: False 
+Accept wildcard characters: False 
+``` 
+
+### -EnableModernListTemplateIds
+
+Specifies list of modern template IDs enabled in tenant.
+
+To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [Get-SPOTenant](Get-SPOTenant.md). 
+
+```yaml
+Type: Guid[] 
+Parameter Sets: (All) 
+Aliases: 
+Applicable: SharePoint Online 
+Required: False 
+Position: Named 
+Default value: None 
+Accept pipeline input: False 
+Accept wildcard characters: False 
+``` 
+
+### -HideSyncButtonOnTeamSite
+
+When set to true, turns off OneDrive sync from all the SharePoint libraries in your organization.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StreamLaunchConfig
+
+Sets the default destination for the Stream app launcher tile
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableRestrictedAccessControl
+
+Lets you and other Global or SharePoint Administrators restrict access to sites.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -BlockDownloadFileTypeIds
+
+Specifies the list of file type IDs that BlockDownloadFileTypePolicy applies to. 
+
+
+The valid values are:
+
+- TeamsMeetingRecording
+
+```yaml
+Type: SPBlockDownloadFileTypeId[]
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ExcludedBlockDownloadGroupIds
+
+Exempts users from specified groups from the block download policy and they can fully download any content for the site.
+
+To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [Get-SPOTenant](Get-SPOTenant.md). 
+
+```yaml
+Type: Guid[] 
+Parameter Sets: (All) 
+Aliases: 
+Applicable: SharePoint Online 
+Required: False 
+Position: Named 
+Default value: None 
+Accept pipeline input: False 
+Accept wildcard characters: False 
+```
+
+### -RecycleBinRetentionPeriod
+Sets the amount of time content is kept in the in recycle bin in Microsoft365.com before it is deleted. 
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnableMediaReactions
+
+Controls whether media reactions are enabled.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AllowSensitivityLabelOnRecords
+
+Controls whether sensitivity labels can be applied to records.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ContentSecurityPolicyEnforcement
+
+Controls whether content security policy is enabled.
 
 PARAMVALUE: $true | $false
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -205,7 +205,7 @@ Set-SPOTenant
  [-StreamLaunchConfig <Int32> ]
  [-EnableRestrictedAccessControl <Boolean> ]
  [-BlockDownloadFileTypeIds <SPBlockDownloadFileTypeId[]> ]
- [-ExcludedBlockDownloadGroupIds <GUID[]> ]
+ [-ExcludedBlockDownloadGroupIds <GUID> ]
  [-RecycleBinRetentionPeriod <Int32> ]
  [-EnableMediaReactions <Boolean> ]
  [-AllowSensitivityLabelOnRecords <Boolean> ]
@@ -980,7 +980,7 @@ Accept wildcard characters: False
 ### -CommentsOnSitePagesDisabled
 
 Disables or enables commenting functionality on the site pages.
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -997,7 +997,7 @@ Accept wildcard characters: False
 ### -CommentsOnFilesDisabled
 
 Disables or enables commenting functionality on the files.
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -1014,7 +1014,7 @@ Accept wildcard characters: False
 ### -CommentsOnListItemsDisabled
 
 Disables or enables commenting functionality on list items.
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -1034,7 +1034,7 @@ Disables or enables the Social Bar.
 
 The Social Bar will appear on all modern SharePoint pages with the exception of the home page of a site. It will give users the ability to like a page, see the number of views, likes, and comments on a page, and see the people who have liked a page.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -1400,7 +1400,7 @@ Accept wildcard characters: False
 
 Enables or disables notifications in OneDrive for Business.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -1418,7 +1418,7 @@ Accept wildcard characters: False
 
 Enables or disables notifications in SharePoint.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -1585,7 +1585,7 @@ Accept wildcard characters: False
 
 Enables or disables owner anonymous notification. If enabled, an email notification will be sent to the OneDrive for Business owners when anonymous links are created or changed.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -1624,7 +1624,7 @@ Accept wildcard characters: False
 
 Prevents external users from resharing files, folders, and sites that they do not own.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -1660,7 +1660,7 @@ Accept wildcard characters: False
 
 Enables or disables the public CDN.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -1975,7 +1975,7 @@ Accept wildcard characters: False
 
 Prevents users from editing Office files in the browser and copying and pasting Office file contents out of the browser window.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -1993,7 +1993,7 @@ Accept wildcard characters: False
 
 Enables OneDrive and SharePoint integration with Microsoft Entra B2B. For more information, see [SharePoint and OneDrive integration with Microsoft Entra B2B](/sharepoint/sharepoint-azureb2b-integration).
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -2323,7 +2323,7 @@ Accept wildcard characters: False
 This parameter has no effect and it was used to opt-out of PST files retention policy changes as communicated in MC256835 (May 2021).
 Starting August 16, 2021, the service started retaining 30 days worth of versions for any PST files stored in OneDrive for Business and SharePoint Online team site document libraries. This change was introduced to prevent cases of previous versions of PST files quickly consuming available storage. The change only impacts previous versions of PST files stored in your document library storage. As a best practice, PST files should not be uploaded on OneDrive for Business and SharePoint Online team site document libraries due to the impact on storage and network bandwidth.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -2341,7 +2341,7 @@ Accept wildcard characters: False
 
 When the feature is disabled ($true), the option [Add shortcut to My files](https://support.microsoft.com/office/add-shortcuts-to-shared-folders-in-onedrive-for-work-or-school-d66b1347-99b7-4470-9360-ffc048d35a33) will be removed; any folders that have already been added will remain on the user's computer.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -2820,7 +2820,7 @@ The valid values are:
 > b. `ExpireVersionsAfterDays` accepts values of 0 to Never Expire or values >= 30 to delete versions that exceed that time period.
 > When version history limits are managed automatically (`EnableAutoExpirationVersionTrim $true`), setting `MajorVersionLimit` or `ExpireVersionsAfterDays` will result in an error as the count limits are set by the service.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -2871,7 +2871,7 @@ Accept wildcard characters: False
 ### -MassDeleteNotificationDisabled
 Enables or disables the mass delete detection feature. When MassDeleteNotificationDisabled is set to $true, tenant admins can perform mass deletion operations without triggering notifications.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3598,7 +3598,7 @@ Accept wildcard characters: False
 ### -AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled
 Enables or disables web property bag update when DenyAddAndCustomizePages is enabled. When AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled is set to $true, web property bag can be updated even if DenyAddAndCustomizePages is turned on when the user had AddAndCustomizePages (prior to DenyAddAndCustomizePages removing it).
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3615,7 +3615,7 @@ Accept wildcard characters: False
 
 Sets the list of security groups who are allowed to share with anonymous (non-authenticated) users as well as authenticated guest users. Each security group is denoted by its GUID object ID in the Entra directory. 
 
-To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [Get-SPOTenant](Get-SPOTenant.md). 
+To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [./Get-SPOTenant.md](Get-SPOTenant.md). 
 
 ```yaml
 Type: Guid[] 
@@ -3633,7 +3633,7 @@ Accept wildcard characters: False
 
 Sets the list of security groups who are only allowed to share with authenticated guest users. Each security group is denoted by its GUID object ID. 
 
-To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [Get-SPOTenant](Get-SPOTenant.md). 
+To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [./Get-SPOTenant.md](Get-SPOTenant.md). 
 
 ```yaml 
 Type: Guid[] 
@@ -3649,7 +3649,7 @@ Accept wildcard characters: False
 ### -ExtendPermissionsToUnprotectedFiles
 This property can be used to turn on/off the capability called "Extended SharePoint permissions to unprotected files". To learn more about this feature check [here](https://aka.ms/ExtendSharePointPermission)
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3665,7 +3665,7 @@ Accept wildcard characters: False
 
 Controls whether legacy browser authentication protocols are enabled.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3682,7 +3682,7 @@ Accept wildcard characters: False
 
 Allows the sharing dialog to include a checkbox offering the user the ability to share to a security group containing every user in the organization.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3731,7 +3731,7 @@ Accept wildcard characters: False
 
 Controls whether Workflow 2010 is enabled.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3768,7 +3768,7 @@ Accept wildcard characters: False
 
 Requires recipients to verify their identity with an email address to access content from an Anyone link.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3807,7 +3807,7 @@ Accept wildcard characters: False
 
 Controls whether sharing SharePoint sites and their content is allowed with users and groups who are not allowed as per the Restricted access control policy.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3824,7 +3824,7 @@ Accept wildcard characters: False
 
 Controls whether Workflow 2013 is enabled.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3841,7 +3841,7 @@ Accept wildcard characters: False
 
 Controls whether collaborative meeting notes are enabled in Microsoft Teams.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3858,7 +3858,7 @@ Accept wildcard characters: False
 
 Controls whether Loop components are available in Microsoft Teams. 
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3875,7 +3875,7 @@ Accept wildcard characters: False
 
 Controls whether users can create a personal list.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3892,7 +3892,7 @@ Accept wildcard characters: False
 
 Controls whether the Viva Connections analytics feature is enabled.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3909,7 +3909,7 @@ Accept wildcard characters: False
 
 Controls whether applications running in app-only mode can access sites protected by information barriers.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3926,7 +3926,7 @@ Accept wildcard characters: False
 
 Specifies list of modern template IDs not enabled in tenant.
 
-To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [Get-SPOTenant](Get-SPOTenant.md). 
+To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [./Get-SPOTenant.md](Get-SPOTenant.md). 
 
 ```yaml
 Type: Guid[] 
@@ -3944,7 +3944,7 @@ Accept wildcard characters: False
 
 Specifies list of modern template IDs enabled in tenant.
 
-To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [Get-SPOTenant](Get-SPOTenant.md). 
+To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [./Get-SPOTenant.md](Get-SPOTenant.md). 
 
 ```yaml
 Type: Guid[] 
@@ -3962,7 +3962,7 @@ Accept wildcard characters: False
 
 When set to true, turns off OneDrive sync from all the SharePoint libraries in your organization.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -3995,7 +3995,7 @@ Accept wildcard characters: False
 
 Lets you and other Global or SharePoint Administrators restrict access to sites.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -4032,7 +4032,7 @@ Accept wildcard characters: False
 
 Exempts users from specified groups from the block download policy and they can fully download any content for the site.
 
-To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [Get-SPOTenant](Get-SPOTenant.md). 
+To set this list to be a specific security group, you need to enter its GUID as the argument. You can enter multiple GUIDs by using commas to separate them. To view the current list, use [./Get-SPOTenant.md](Get-SPOTenant.md). 
 
 ```yaml
 Type: Guid[] 
@@ -4065,7 +4065,7 @@ Accept wildcard characters: False
 
 Controls whether media reactions are enabled.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -4082,7 +4082,7 @@ Accept wildcard characters: False
 
 Controls whether sensitivity labels can be applied to records.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -4099,7 +4099,7 @@ Accept wildcard characters: False
 
 Controls whether content security policy is enabled.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean
@@ -4116,7 +4116,7 @@ Accept wildcard characters: False
 
 Controls SharePoint spaces activation.
 
-PARAMVALUE: $true | $false
+PARAMVALUE: True | False
 
 ```yaml
 Type: Boolean

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -205,7 +205,7 @@ Set-SPOTenant
  [-StreamLaunchConfig <Int32> ]
  [-EnableRestrictedAccessControl <Boolean> ]
  [-BlockDownloadFileTypeIds <SPBlockDownloadFileTypeId[]> ]
- [-ExcludedBlockDownloadGroupIds <GUID> ]
+ [-ExcludedBlockDownloadGroupIds <Guid[]> ]
  [-RecycleBinRetentionPeriod <Int32> ]
  [-EnableMediaReactions <Boolean> ]
  [-AllowSensitivityLabelOnRecords <Boolean> ]

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenant.md
@@ -210,6 +210,7 @@ Set-SPOTenant
  [-EnableMediaReactions <Boolean> ]
  [-AllowSensitivityLabelOnRecords <Boolean> ]
  [-ContentSecurityPolicyEnforcement <Boolean> ]
+ [- DisableSpacesActivation <Boolean>]
  [<CommonParameters>]
 ```
 
@@ -3765,7 +3766,7 @@ Accept wildcard characters: False
 
 ### -AnyoneLinkTrackUsers
 
-Requires recipients to verify their identity with an email address to access content from an Anyone link
+Requires recipients to verify their identity with an email address to access content from an Anyone link.
 
 PARAMVALUE: $true | $false
 
@@ -3976,7 +3977,7 @@ Accept wildcard characters: False
 
 ### -StreamLaunchConfig
 
-Sets the default destination for the Stream app launcher tile
+Sets the default destination for the Stream app launcher tile.
 
 ```yaml
 Type: Int32
@@ -4110,6 +4111,24 @@ Default value: False
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -DisableSpacesActivation
+
+Controls SharePoint spaces activation.
+
+PARAMVALUE: $true | $false
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Applicable: SharePoint Online
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ## RELATED LINKS
 
 [Getting started with SharePoint Online Management Shell](/powershell/sharepoint/sharepoint-online/connect-sharepoint-online)


### PR DESCRIPTION
Adding the below supported parameter to Set-SPOTenant documentation
[-LegacyBrowserAuthProtocolsEnabled <Boolean>]
[-EnableDiscoverableByOrganizationForVideos <Boolean> ]
[-RestrictedAccessControlforSitesErrorHelpLink <String> ]
[-SensitivityLabel <String> ]
[-DisableWorkflow2010 <Boolean> ]
[-Sites <String> ]
[-AnyoneLinkTrackUsers <Boolean> ]
[-OneDriveBlockGuestsAsSiteAdmin <SharingState> ]
[-AllowSharingOutsideRestrictedAccessControlGroups <Boolean> ]
[-Workflows2013Enabled <Boolean> ]
[-IsCollabMeetingNotesFluidEnabled <Boolean> ]
[-IsLoopEnabled <Boolean> ]
[-DisablePersonalListCreation <Boolean> ]
[-DisableVivaConnectionsAnalytics <Boolean> ]
[-AppBypassInformationBarriers <Boolean> ]
[-DisableModernListTemplateIds <Guid[]> ]
[-EnableModernListTemplateIds <Guid[]> ]
[-HideSyncButtonOnTeamSite <Boolean> ]
[-StreamLaunchConfig <Int32> ]
[-EnableRestrictedAccessControl <Boolean> ]
[-BlockDownloadFileTypeIds <SPBlockDownloadFileTypeId[]> ]
[-ExcludedBlockDownloadGroupIds <GUID[]> ]
[-RecycleBinRetentionPeriod <Int32> ]
[-EnableMediaReactions <Boolean> ]
[-AllowSensitivityLabelOnRecords <Boolean> ]
[-ContentSecurityPolicyEnforcement <Boolean> ]
[-ExcludeBlockDownloadSharePointGroups <String>]

Adding the below supported parameter to Set-SPOSite documentation
[-ReadOnlyForUnmanagedDevices <Boolean>]
[-ExcludedBlockDownloadGroupIds <GUID[]>]
[-ExcludeBlockDownloadPolicySiteOwners <Boolean>]
[-ReadOnlyForBlockDownloadPolicy <Boolean>]
[-AuthenticationContextAccessType <SPOAuthenticationContextPolicyAccessType>]
[-HubSiteId <Guid[]>]
[-InformationBarriersMode <String>]
[-RestrictContentOrgWideSearch <Boolean>]
[-RestrictedAccessControl <Boolean>]
[-RestrictedAccessControlGroups <Guid[]>]
[-AddRestrictedAccessControlGroups <Guid[]>]
[-RemoveRestrictedAccessControlGroups <Guid[]>]
[-ClearRestrictedAccessControl <SwitchParameter>]