### PR TITLE
Correct invisible content (disallowed-html-tag)

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Revoke-SPOUserSession.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Revoke-SPOUserSession.md
@@ -39,9 +39,9 @@ Possible results for this cmdlet are:
 Result |                                                                                             Reason
 --- | ---
 Warning : We couldn't find the user@contoso.com. Check for typos and try again. |                    Invalid input for -User parameter.
-We successfully signed out <user> from all devices. |                                                Successful instantaneous revocation.
-It can take up to an hour to sign out <user> from all devices. |                                     Successful non-instantaneous revocation.
-Sorry, something went wrong and we couldn't sign out <user> from any device. |                       The cmdlet did not successfully execute.
+We successfully signed out \<user\> from all devices. |                                                Successful instantaneous revocation.
+It can take up to an hour to sign out \<user\> from all devices. |                                     Successful non-instantaneous revocation.
+Sorry, something went wrong and we couldn't sign out \<user\> from any device. |                       The cmdlet did not successfully execute.
 The cmdlet will be available in the future, but it isn't ready for use in your organization yet. |   The cmdlet has been disabled for the tenant.
 
 ## EXAMPLES

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOMigrationPackageAzureSource.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOMigrationPackageAzureSource.md
@@ -164,7 +164,7 @@ Accept wildcard characters: False
 
 ### -FileContainerName
 
-The optional name of the Azure Blob Storage container that will be created if it does not currently exist. It will hold the uploaded package content files. The value must be in lower case and conform to Azure's container naming rules. If this not supplied a name will be generated using the format <GUID>-files.
+The optional name of the Azure Blob Storage container that will be created if it does not currently exist. It will hold the uploaded package content files. The value must be in lower case and conform to Azure's container naming rules. If this not supplied a name will be generated using the format \<GUID\>-files.
 
 ```yaml
 Type: String
@@ -274,7 +274,7 @@ Accept wildcard characters: False
 
 ### -PackageContainerName
 
-The optional name of the Azure Blob Storage container that will be created if it does not currently exist. It will hold the uploaded package metadata files. The value must be in lower case and conform to Azure's container naming rules. If this not supplied a name will be generated using the format <GUID>-package.
+The optional name of the Azure Blob Storage container that will be created if it does not currently exist. It will hold the uploaded package metadata files. The value must be in lower case and conform to Azure's container naming rules. If this not supplied a name will be generated using the format \<GUID\>-package.
 
 ```yaml
 Type: String

--- a/sharepoint/sharepoint-ps/sharepoint-online/Unregister-SPOHubSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Unregister-SPOHubSite.md
@@ -37,7 +37,7 @@ Disables the hub site feature on a site so that it is no longer a hub site. Asso
 Unregister-SPOHubSite -Identity <guid>
 ```
 
-This example removes a site from the hub site list based on unique hub identifier (<guid>).
+This example removes a site from the hub site list based on unique hub identifier (\<guid\>).
 
 ### Example 2
 


### PR DESCRIPTION
When the build interprets something like "\<GUID\>" as an HTML tag that's disallowed, it does not include that content in the rendered page. One way to solve that is to add backslashes before the angle brackets: "\\\<GUID\\\>"