### PR TITLE
Corrected parameter list for this command

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Export-SPODataAccessGovernanceInsight.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Export-SPODataAccessGovernanceInsight.md
@@ -15,7 +15,7 @@ ms.reviewer:
 
 ## SYNOPSIS
 
-This cmdlet downloads the Data Access Governance (DAG) reports to the current working directory.
+This cmdlet downloads the Data Access Governance (DAG) reports to the specified path. The default is the "Downloads" folder.
 
 ## SYNTAX
 
@@ -25,7 +25,7 @@ Export-SPODataAccessGovernanceInsight -ReportID <Guid> [<CommonParameters>]
 
 ## DESCRIPTION
 
-This cmdlet exports or downloads the DAG report, specified by the `ReportID`, to the current working directory. The `ReportID` is shown in the output of the [Start-SPODataAccessGovernanceInsight](./Start-SPODataAccessGovernanceInsight.md) command. It can also be fetched from the output of the [Get-SPODataAccessGovernanceInsight](./Get-SPODataAccessGovernanceInsight.md) command.
+This cmdlet exports or downloads the DAG report, specified by the `ReportID`, to the path as specified with `DownloadPath`. If not specified, the commands downloads the report to the "Downloads" folder. The `ReportID` is shown in the output of the [Start-SPODataAccessGovernanceInsight](./Start-SPODataAccessGovernanceInsight.md) command. It can also be fetched from the output of the [Get-SPODataAccessGovernanceInsight](./Get-SPODataAccessGovernanceInsight.md) command.
 
 ## EXAMPLES
 
@@ -49,6 +49,22 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DownloadPath
+
+Specifies the path to which the report should be downloaded. The default path is the "Downloads" folder.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False


### PR DESCRIPTION
Corresponding code PR: [Pull request 1657924: Feature 2197179: Added optional parameters DownloadPath and FileName to the export command in PowerShell - Repos](https://dev.azure.com/onedrive/SharePoint%20Online/_git/SPO.Core/pullrequest/1657924?path=%2Fspo%2Fdev%2FClientCmdLets%2FCmdLets%2FDataGovernance%2FSPDataGovernanceInsightCmdlets.cs)

This was submitted before doc submission became mandatory. The latest documentation doesn't reflect this properly and hence the correction.