### PR TITLE
Update Update-SPProfileSync.md

### DIFF
--- a/sharepoint/sharepoint-server-ps/sharepoint-server/Update-SPProfileSync.md
+++ b/sharepoint/sharepoint-server-ps/sharepoint-server/Update-SPProfileSync.md
@@ -28,7 +28,7 @@ The Update-SPProfileSync cmdlet updates the configuration of the User Profile Sy
 
 ### ------------EXAMPLE 1-----------
 ```powershell
-Update-SPProfileSync -IgnoreIsActive:$false
+Update-SPProfileSync -IgnoreIsActive:$true
 ```
 
 This example updates the User Profile Synchronization job marking it to sync all users irrespective of their activity, without prompting for user confirmation.


### PR DESCRIPTION
The provided example indicates that setting IgnoreIsActive to $false will synchronize all users, regardless of their activity status. However, to include all users in the synchronization, IgnoreIsActive should be set to $true.

---
Update-SPProfileSync -IgnoreIsActive:$false
This example updates the User Profile Synchronization job marking it to sync all users irrespective of their activity, without prompting for user confirmation. ---

Therefore, to ensure all users are included in the synchronization, please set IgnoreIsActive to $true.