### PR TITLE
Made fixes to include table of feature names + improve formatting

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
@@ -32,14 +32,14 @@ Clears the pre-authentication settings for either the allow or deny list.
 
 ## EXAMPLES
 
-### Example 1: Clear all pre-authentication settings from the allow list
+### Example 1
 ```powershell
 PS C:\> Clear-SPOTenantPreAuthSettings –Type Allow
 ```
 
 This example clears all list items from the allow list.
 
-### Example 2: Clear all pre-authentication settings from the deny list
+### Example 2
 
 ```powershell
 PS C:\> Clear-SPOTenantPreAuthSettings –Type Deny 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
@@ -106,6 +106,17 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1).
 
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
 ## RELATED LINKS
+
 - [Get-SPOTenantPreAuthSettings](Get-SPOTenantPreAuthSettings.md)
 - [Set-SPOTenantPreAuthSettings](Set-SPOTenantPreAuthSettings.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
@@ -1,14 +1,8 @@
 ---
-external help file: sharepointonline.xml
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version: https://learn.microsoft.com/powershell/module/sharepoint-online/clear-spotenantpreauthsettings
-applicable: SharePoint Online
-title: Clear-SPOTenantPreAuthSettings
+online version:
 schema: 2.0.0
-author: lw-msft
-ms.author: laurenwong
-ms.reviewer:
-manager: bhaveshd
 ---
 
 # Clear-SPOTenantPreAuthSettings
@@ -38,33 +32,48 @@ Clears the pre-authentication settings for either the allow or deny list.
 
 ## EXAMPLES
 
-### EXAMPLE 1
-
+### Example 1
 ```powershell
-Clear-SPOTenantPreAuthSettings –Type Allow
+PS C:\> Clear-SPOTenantPreAuthSettings –Type Allow
 ```
 
 This example clears all list items from the allow list.
 
-### EXAMPLE 2
+### Example 2
 
 ```powershell
-Clear-SPOTenantPreAuthSettings –Type Deny 
+PS C:\> Clear-SPOTenantPreAuthSettings –Type Deny 
 ```
 
 This example clears all list items from the deny list. 
 
 ## PARAMETERS
 
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Type
 
 This parameter indicates whether the cmdlet is interacting with the allow list or the deny list.
 
-PARAMVALUE: Allow | Deny
-
 ```yaml
 Type: TenantPreAuthSettingsListType
-Applicable: SharePoint Online
+Parameter Sets: (All)
+Aliases:
+Accepted values: Allow, Deny
+
 Required: True
 Position: Named
 Default value: None
@@ -72,10 +81,34 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
 
 ## RELATED LINKS
-
 - [Get-SPOTenantPreAuthSettings](Get-SPOTenantPreAuthSettings.md)
 - [Set-SPOTenantPreAuthSettings](Set-SPOTenantPreAuthSettings.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
@@ -1,8 +1,14 @@
 ---
-external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+external help file: sharepointonline.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/sharepoint-online/clear-spotenantpreauthsettings
+applicable: SharePoint Online
+title: Clear-SPOTenantPreAuthSettings
 schema: 2.0.0
+author: lw-msft
+ms.author: laurenwong
+ms.reviewer:
+manager: bhaveshd
 ---
 
 # Clear-SPOTenantPreAuthSettings
@@ -34,7 +40,7 @@ Clears the pre-authentication settings for either the allow or deny list.
 
 ### Example 1
 ```powershell
-PS C:\> Clear-SPOTenantPreAuthSettings –Type Allow
+Clear-SPOTenantPreAuthSettings –Type Allow
 ```
 
 This example clears all list items from the allow list.
@@ -42,7 +48,7 @@ This example clears all list items from the allow list.
 ### Example 2
 
 ```powershell
-PS C:\> Clear-SPOTenantPreAuthSettings –Type Deny 
+Clear-SPOTenantPreAuthSettings –Type Deny 
 ```
 
 This example clears all list items from the deny list. 
@@ -98,16 +104,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
-## INPUTS
-
-### None
-
-## OUTPUTS
-
-### System.Object
-## NOTES
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1).
 
 ## RELATED LINKS
 - [Get-SPOTenantPreAuthSettings](Get-SPOTenantPreAuthSettings.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Clear-SPOTenantPreAuthSettings.md
@@ -32,14 +32,14 @@ Clears the pre-authentication settings for either the allow or deny list.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1: Clear all pre-authentication settings from the allow list
 ```powershell
 PS C:\> Clear-SPOTenantPreAuthSettings –Type Allow
 ```
 
 This example clears all list items from the allow list.
 
-### Example 2
+### Example 2: Clear all pre-authentication settings from the deny list
 
 ```powershell
 PS C:\> Clear-SPOTenantPreAuthSettings –Type Deny 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantPreAuthSettings.md
@@ -1,8 +1,14 @@
 ---
-external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+external help file: sharepointonline.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/sharepoint-online/get-spotenantpreauthsettings
+applicable: SharePoint Online
+title: Get-SPOTenantPreAuthSettings
 schema: 2.0.0
+author: lw-msft
+ms.author: laurenwong
+ms.reviewer:
+manager: bhaveshd
 ---
 
 # Get-SPOTenantPreAuthSettings
@@ -35,7 +41,7 @@ Gets the configuration of pre-authentication.
 ### Example 1
 
 ```powershell
-PS C:\> Get-SPOTenantPreAuthSettings
+Get-SPOTenantPreAuthSettings
 ```
 
 This example returns all the pre-authentication settings for the tenant as an object.
@@ -43,7 +49,7 @@ This example returns all the pre-authentication settings for the tenant as an ob
 ### Example 2
 
 ```powershell
-PS C:\> Get-SPOTenantPreAuthSettings | ConvertTo-Json
+Get-SPOTenantPreAuthSettings | ConvertTo-Json
 ```
 
 Gets all the pre-authentication settings for the tenant. Note that this example uses `ConvertTo-Json` to display the settings in JSON format since more complex Allow or Deny lists may be hard to read as an object.
@@ -51,16 +57,7 @@ Gets all the pre-authentication settings for the tenant. Note that this example 
 ## PARAMETERS
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
-## INPUTS
-
-### None
-
-## OUTPUTS
-
-### System.Object
-## NOTES
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1).
 
 ## RELATED LINKS
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantPreAuthSettings.md
@@ -32,7 +32,7 @@ Gets the configuration of pre-authentication.
 
 ## EXAMPLES
 
-### Example 1: Get all pre-authentication settings as an object
+### Example 1
 
 ```powershell
 PS C:\> Get-SPOTenantPreAuthSettings
@@ -40,7 +40,7 @@ PS C:\> Get-SPOTenantPreAuthSettings
 
 This example returns all the pre-authentication settings for the tenant as an object.
 
-### Example 2: Get all pre-authentication settings in JSON format
+### Example 2
 
 ```powershell
 PS C:\> Get-SPOTenantPreAuthSettings | ConvertTo-Json

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantPreAuthSettings.md
@@ -1,14 +1,8 @@
 ---
-external help file: sharepointonline.xml
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version: https://learn.microsoft.com/powershell/module/sharepoint-online/get-spotenantpreauthsettings
-applicable: SharePoint Online
-title: Get-SPOTenantPreAuthSettings
+online version:
 schema: 2.0.0
-author: lw-msft
-ms.author: laurenwong
-ms.reviewer:
-manager: bhaveshd
 ---
 
 # Get-SPOTenantPreAuthSettings
@@ -38,18 +32,18 @@ Gets the configuration of pre-authentication.
 
 ## EXAMPLES
 
-### EXAMPLE 1
+### Example 1: Get all pre-authentication settings as an object
 
 ```powershell
-Get-SPOTenantPreAuthSettings
+PS C:\> Get-SPOTenantPreAuthSettings
 ```
 
 This example returns all the pre-authentication settings for the tenant as an object.
 
-### EXAMPLE 2
+### Example 2: Get all pre-authentication settings in JSON format
 
 ```powershell
-Get-SPOTenantPreAuthSettings | ConvertTo-Json
+PS C:\> Get-SPOTenantPreAuthSettings | ConvertTo-Json
 ```
 
 Gets all the pre-authentication settings for the tenant. Note that this example uses `ConvertTo-Json` to display the settings in JSON format since more complex Allow or Deny lists may be hard to read as an object.
@@ -57,7 +51,16 @@ Gets all the pre-authentication settings for the tenant. Note that this example 
 ## PARAMETERS
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
 
 ## RELATED LINKS
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Get-SPOTenantPreAuthSettings.md
@@ -59,6 +59,16 @@ Gets all the pre-authentication settings for the tenant. Note that this example 
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1).
 
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
 ## RELATED LINKS
 
 - [Set-SPOTenantPreAuthSettings](Set-SPOTenantPreAuthSettings.md)

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
@@ -280,6 +280,8 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
+### Feature Names
+
 The `-IncludedFeatures` and `-ExcludedFeatures` use feature names from the following table. It explicitly mentions if the feature will be broken if it is disabled via the PowerShell cmdlet.
 
 | Feature name         | Description                                                              | Additional Information                                                                                     |

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
@@ -271,6 +271,14 @@ Accept wildcard characters: False
 ### CommonParameters
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1).
 
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
 ## NOTES
 
 The `-IncludedFeatures` and `-ExcludedFeatures` use feature names from the following table. It explicitly mentions if the feature will be broken if it is disabled via the PowerShell cmdlet.

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
@@ -1,8 +1,14 @@
 ---
-external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+external help file: sharepointonline.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/sharepoint-online/set-spotenantpreauthsettings
+applicable: SharePoint Online
+title: Set-SPOTenantPreAuthSettings
 schema: 2.0.0
+author: lw-msft
+ms.author: laurenwong
+ms.reviewer:
+manager: bhaveshd
 ---
 
 # Set-SPOTenantPreAuthSettings
@@ -56,16 +62,16 @@ You must be a SharePoint Administrator to run the cmdlet.
 
 ### Example 1
 ```powershell
-PS C:\> Set-SPOTenantPreAuthSettings -IsDisabled $true 
+Set-SPOTenantPreAuthSettings -IsDisabled $true 
 
-PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
+Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
 ```
 
 This example disables pre-authentication overall and adds a setting that allows two apps to use pre-authentication for all features.
 
 ### Example 2
 ```powershell
-PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e" -ExcludedApps "" -IncludedFeatures "" -ExcludedFeatures ""
+Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e" -ExcludedApps "" -IncludedFeatures "" -ExcludedFeatures ""
 ```
 
 This example performs the same function as example 1 except in this case the switches for `-ExcludedApps`, `-IncludedFeatures`, and `-ExcludedFeatures` are added to the cmdlet.
@@ -74,16 +80,16 @@ These switches are assumed to take the default value of `""` if not used with th
 
 ### Example 3
 ```powershell
-PS C:\> Set-SPOTenantPreAuthSettings -Remove -Id "368dde6f-c857-4383-a8a7-02a04a294e6d"
+Set-SPOTenantPreAuthSettings -Remove -Id "368dde6f-c857-4383-a8a7-02a04a294e6d"
 ```
 
 This example will remove an existing item from the current list of items. The remove switch can remove allow or deny entries from the list.
 
 ### Example 4
 ```powershell
-PS C:\> Set-SPOTenantPreAuthSettings -IsDisabled $true 
+Set-SPOTenantPreAuthSettings -IsDisabled $true 
 
-PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Allow -ExcludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42" -ExcludedFeatures "Download,WebRenderingEmbed" 
+Set-SPOTenantPreAuthSettings -Add -Type Allow -ExcludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42" -ExcludedFeatures "Download,WebRenderingEmbed" 
 ```
 
 This example disables pre-authentication overall and allows all apps apart from one to use pre-authentication for all features except for `"Download"` and `"WebRenderingEmbed"`. 
@@ -92,11 +98,11 @@ In this case, the app `"029e7c27-4b9c-4f8b-ba32-b96249468d42"` will always be de
 
 ### Example 5
 ```powershell
-PS C:\> Set-SPOTenantPreAuthSettings -IsDisabled $true
+Set-SPOTenantPreAuthSettings -IsDisabled $true
 
-PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42" -IncludedFeatures "OfficeOnline,WebRenderingEmbed,Download"
+Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42" -IncludedFeatures "OfficeOnline,WebRenderingEmbed,Download"
 
-PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Deny -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
+Set-SPOTenantPreAuthSettings -Add -Type Deny -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
 ```
 
 This example disables pre-authentication overall but contains an overlap between the settings in the Allow list and Deny list. It first allows an app to use pre-authentication for the `"OfficeOnline"`, `"WebRenderingEmbed"`, and `"Download"` features. But in the final execution of the cmdlet, it denies the same app from using pre-authentication for all features. 
@@ -105,9 +111,9 @@ In this case, the app `"029e7c27-4b9c-4f8b-ba32-b96249468d42"` would not be allo
 
 ### Example 6
 ```powershell
-PS C:\> Set-SPOTenantPreAuthSettings -IsDisabled $false
+Set-SPOTenantPreAuthSettings -IsDisabled $false
 
-PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Deny -IncludedApps "Empty"
+Set-SPOTenantPreAuthSettings -Add -Type Deny -IncludedApps "Empty"
 ```
 This example enables pre-authentication overall and denies requests that are not coming from an app (e.g. requests coming via a browser) from using pre-authentication for all features. 
 
@@ -268,15 +274,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
-
-## INPUTS
-
-### None
-
-## OUTPUTS
-
-### System.Object
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1).
 
 ## NOTES
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
@@ -66,14 +66,12 @@ Set-SPOTenantPreAuthSettings -IsDisabled $true
 
 Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
 ```
-
 This example disables pre-authentication overall and adds a setting that allows two apps to use pre-authentication for all features.
 
 ### Example 2
 ```powershell
 Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e" -ExcludedApps "" -IncludedFeatures "" -ExcludedFeatures ""
 ```
-
 This example performs the same function as example 1 except in this case the switches for `-ExcludedApps`, `-IncludedFeatures`, and `-ExcludedFeatures` are added to the cmdlet.
 
 These switches are assumed to take the default value of `""` if not used with the cmdlet and example 2 is used to demonstrate the complete set of switches only. 
@@ -82,7 +80,6 @@ These switches are assumed to take the default value of `""` if not used with th
 ```powershell
 Set-SPOTenantPreAuthSettings -Remove -Id "368dde6f-c857-4383-a8a7-02a04a294e6d"
 ```
-
 This example will remove an existing item from the current list of items. The remove switch can remove allow or deny entries from the list.
 
 ### Example 4
@@ -91,7 +88,6 @@ Set-SPOTenantPreAuthSettings -IsDisabled $true
 
 Set-SPOTenantPreAuthSettings -Add -Type Allow -ExcludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42" -ExcludedFeatures "Download,WebRenderingEmbed" 
 ```
-
 This example disables pre-authentication overall and allows all apps apart from one to use pre-authentication for all features except for `"Download"` and `"WebRenderingEmbed"`. 
 
 In this case, the app `"029e7c27-4b9c-4f8b-ba32-b96249468d42"` will always be denied from using pre-authentication since it is excluded from the allow list setting. Any other app will be allowed to use pre-authentication for any feature apart from `"Download"` and `"WebRenderingEmbed"`. 
@@ -104,7 +100,6 @@ Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-
 
 Set-SPOTenantPreAuthSettings -Add -Type Deny -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
 ```
-
 This example disables pre-authentication overall but contains an overlap between the settings in the Allow list and Deny list. It first allows an app to use pre-authentication for the `"OfficeOnline"`, `"WebRenderingEmbed"`, and `"Download"` features. But in the final execution of the cmdlet, it denies the same app from using pre-authentication for all features. 
 
 In this case, the app `"029e7c27-4b9c-4f8b-ba32-b96249468d42"` would not be allowed to use pre-authentication for any of the allow-listed features despite having the setting. This is because the Deny list takes precedence over the Allow list. 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
@@ -280,8 +280,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-### Feature Names
-
 The `-IncludedFeatures` and `-ExcludedFeatures` use feature names from the following table. It explicitly mentions if the feature will be broken if it is disabled via the PowerShell cmdlet.
 
 | Feature name         | Description                                                              | Additional Information                                                                                     |
@@ -297,9 +295,6 @@ The `-IncludedFeatures` and `-ExcludedFeatures` use feature names from the follo
 | WebRendering         | Scenarios for rendering previews of files in browser.                    |                                                                                                            |
 | WebRenderingEmbed    | Embed SharePoint files in another application. 3rd party application and some 1st party applications may be broken | [Embed Web Part](https://support.microsoft.com/office/add-content-to-your-page-using-the-embed-web-part-721f3b2f-437f-45ef-ac4e-df29dba74de8) |
 | Whiteboard           | Teams integration with Whiteboard app will be broken for anonymous and guest users. | [Use Whiteboard in a Teams meeting - Microsoft Support](https://support.microsoft.com/office/use-whiteboard-in-a-teams-meeting-26f87802-b37f-4af0-806d-af79fbfb8ae6) |
-
-### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-5.1).
 
 ## RELATED LINKS
 

--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md
@@ -1,14 +1,8 @@
 ---
-external help file: sharepointonline.xml
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version: https://learn.microsoft.com/powershell/module/sharepoint-online/set-spotenantpreauthsettings
-applicable: SharePoint Online
-title: Set-SPOTenantPreAuthSettings
+online version:
 schema: 2.0.0
-author: lw-msft
-ms.author: laurenwong
-ms.reviewer:
-manager: bhaveshd
 ---
 
 # Set-SPOTenantPreAuthSettings
@@ -62,53 +56,58 @@ You must be a SharePoint Administrator to run the cmdlet.
 
 ### Example 1
 ```powershell
-Set-SPOTenantPreAuthSettings -IsDisabled $true 
+PS C:\> Set-SPOTenantPreAuthSettings -IsDisabled $true 
 
-Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
+PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
 ```
+
 This example disables pre-authentication overall and adds a setting that allows two apps to use pre-authentication for all features.
 
 ### Example 2
 ```powershell
-Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e" -ExcludedApps "" -IncludedFeatures "" -ExcludedFeatures ""
+PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e" -ExcludedApps "" -IncludedFeatures "" -ExcludedFeatures ""
 ```
+
 This example performs the same function as example 1 except in this case the switches for `-ExcludedApps`, `-IncludedFeatures`, and `-ExcludedFeatures` are added to the cmdlet.
 
 These switches are assumed to take the default value of `""` if not used with the cmdlet and example 2 is used to demonstrate the complete set of switches only. 
 
 ### Example 3
 ```powershell
-Set-SPOTenantPreAuthSettings -Remove -Id "368dde6f-c857-4383-a8a7-02a04a294e6d"
+PS C:\> Set-SPOTenantPreAuthSettings -Remove -Id "368dde6f-c857-4383-a8a7-02a04a294e6d"
 ```
+
 This example will remove an existing item from the current list of items. The remove switch can remove allow or deny entries from the list.
 
 ### Example 4
 ```powershell
-Set-SPOTenantPreAuthSettings -IsDisabled $true 
+PS C:\> Set-SPOTenantPreAuthSettings -IsDisabled $true 
 
-Set-SPOTenantPreAuthSettings -Add -Type Allow -ExcludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42" -ExcludedFeatures "Download,WebRenderingEmbed" 
+PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Allow -ExcludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42" -ExcludedFeatures "Download,WebRenderingEmbed" 
 ```
+
 This example disables pre-authentication overall and allows all apps apart from one to use pre-authentication for all features except for `"Download"` and `"WebRenderingEmbed"`. 
 
 In this case, the app `"029e7c27-4b9c-4f8b-ba32-b96249468d42"` will always be denied from using pre-authentication since it is excluded from the allow list setting. Any other app will be allowed to use pre-authentication for any feature apart from `"Download"` and `"WebRenderingEmbed"`. 
 
 ### Example 5
 ```powershell
-Set-SPOTenantPreAuthSettings -IsDisabled $true
+PS C:\> Set-SPOTenantPreAuthSettings -IsDisabled $true
 
-Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42" -IncludedFeatures "OfficeOnline,WebRenderingEmbed,Download"
+PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Allow -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42" -IncludedFeatures "OfficeOnline,WebRenderingEmbed,Download"
 
-Set-SPOTenantPreAuthSettings -Add -Type Deny -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
+PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Deny -IncludedApps "029e7c27-4b9c-4f8b-ba32-b96249468d42,0ab82eba-96c7-4681-9f75-c18437e20d0e"
 ```
+
 This example disables pre-authentication overall but contains an overlap between the settings in the Allow list and Deny list. It first allows an app to use pre-authentication for the `"OfficeOnline"`, `"WebRenderingEmbed"`, and `"Download"` features. But in the final execution of the cmdlet, it denies the same app from using pre-authentication for all features. 
 
 In this case, the app `"029e7c27-4b9c-4f8b-ba32-b96249468d42"` would not be allowed to use pre-authentication for any of the allow-listed features despite having the setting. This is because the Deny list takes precedence over the Allow list. 
 
 ### Example 6
 ```powershell
-Set-SPOTenantPreAuthSettings -IsDisabled $false
+PS C:\> Set-SPOTenantPreAuthSettings -IsDisabled $false
 
-Set-SPOTenantPreAuthSettings -Add -Type Deny -IncludedApps "Empty"
+PS C:\> Set-SPOTenantPreAuthSettings -Add -Type Deny -IncludedApps "Empty"
 ```
 This example enables pre-authentication overall and denies requests that are not coming from an app (e.g. requests coming via a browser) from using pre-authentication for all features. 
 
@@ -130,8 +129,9 @@ This parameter specifies that the operation of the cmdlet is to Add a setting to
 ```yaml
 Type: SwitchParameter
 Parameter Sets: AddListItem
-Applicable: SharePoint Online
-Required: False
+Aliases:
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -140,14 +140,13 @@ Accept wildcard characters: False
 
 ### -ExcludedApps
 
-This parameter value contains the apps ids to configure within the `-ExcludedApps` scope.
-
-PARAMVALUE: `"Empty"`, `""`, or a comma-separated list of app IDs
+This parameter value contains the apps ids to configure within the `-ExcludedApps` scope. Possible values include: `""`, `"Empty"`, or a comma-separated list of app IDs.
 
 ```yaml
 Type: String
 Parameter Sets: AddListItem
-Applicable: SharePoint Online
+Aliases:
+
 Required: False
 Position: Named
 Default value: ""
@@ -157,14 +156,13 @@ Accept wildcard characters: False
 
 ### -ExcludedFeatures
 
-This parameter value contains the feature names to configure within the `-ExcludedFeatures` scope. 
-
-PARAMVALUE: `"Empty"`, `""`, or a comma-separated list of app IDs
+This parameter value contains the feature names to configure within the `-ExcludedFeatures` scope. Possible values include: `""` or a comma-separated list of feature names (see NOTES section below).
 
 ```yaml
 Type: String
 Parameter Sets: AddListItem
-Applicable: SharePoint Online
+Aliases:
+
 Required: False
 Position: Named
 Default value: ""
@@ -179,7 +177,8 @@ This parameter identifies the list item setting to remove from the current confi
 ```yaml
 Type: String
 Parameter Sets: RemoveListItem
-Applicable: SharePoint Online
+Aliases:
+
 Required: True
 Position: Named
 Default value: None
@@ -189,14 +188,13 @@ Accept wildcard characters: False
 
 ### -IncludedApps
 
-This parameter value contains the app ids to configure within the `-IncludedApps` scope. 
-
-PARAMVALUE: `"Empty"`, `""`, or a comma-separated list of app IDs
+This parameter value contains the app ids to configure within the `-IncludedApps` scope. Possible values include: `""`, `"Empty"`, or a comma-separated list of app IDs.
 
 ```yaml
 Type: String
 Parameter Sets: AddListItem
-Applicable: SharePoint Online
+Aliases:
+
 Required: False
 Position: Named
 Default value: ""
@@ -206,14 +204,13 @@ Accept wildcard characters: False
 
 ### -IncludedFeatures
 
-This parameter value contains the feature names to configure within the `-IncludedFeatures` scope. 
-
-PARAMVALUE: `"Empty"`, `""`, or a comma-separated list of app IDs
+This parameter value contains the feature names to configure within the `-IncludedFeatures` scope. Possible values include: `""` or a comma-separated list of feature names (see NOTES section below).
 
 ```yaml
 Type: String
 Parameter Sets: AddListItem
-Applicable: SharePoint Online
+Aliases:
+
 Required: False
 Position: Named
 Default value: ""
@@ -225,12 +222,11 @@ Accept wildcard characters: False
 
 This parameter allows the administrator to toggle pre-authentication for all apps and features to be either enabled or disabled.
 
-PARAMVALUE: True | False
-
 ```yaml
 Type: Boolean
 Parameter Sets: IsDisabled
-Applicable: SharePoint Online
+Aliases:
+
 Required: True
 Position: Named
 Default value: False
@@ -245,8 +241,9 @@ This parameter specifies that the operation of the cmdlet is to Remove a setting
 ```yaml
 Type: SwitchParameter
 Parameter Sets: RemoveListItem
-Applicable: SharePoint Online
-Required: False
+Aliases:
+
+Required: True
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -257,12 +254,12 @@ Accept wildcard characters: False
 
 This parameter indicates whether the cmdlet is interacting with the allow list or the deny list. 
 
-PARAMVALUE: Allow | Deny
-
 ```yaml
 Type: TenantPreAuthSettingsListType
 Parameter Sets: AddListItem
-Applicable: SharePoint Online
+Aliases:
+Accepted values: Allow, Deny
+
 Required: True
 Position: Named
 Default value: None
@@ -270,7 +267,18 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### Feature Names
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
 
 The `-IncludedFeatures` and `-ExcludedFeatures` use feature names from the following table. It explicitly mentions if the feature will be broken if it is disabled via the PowerShell cmdlet.
 


### PR DESCRIPTION
I noticed that the public Set-SPOTenantPreAuthSettings page ([Set-SPOTenantPreAuthSettings (Microsoft.Online.SharePoint.PowerShell) | Microsoft Learn](https://learn.microsoft.com/en-us/powershell/module/sharepoint-online/set-spotenantpreauthsettings?view=sharepoint-ps)) does not include the table of feature names at the end of the page.
 
![image](https://github.com/user-attachments/assets/40232b94-05f3-4193-993c-bca75e9f7b7c)


If you go to the Set-SPOTenantPreAuthSettings.md page via GitHub, it shows up ([OfficeDocs-SharePoint-PowerShell/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md at main · MicrosoftDocs/OfficeDocs-SharePoint-PowerShell](https://github.com/MicrosoftDocs/OfficeDocs-Sharepoint-PowerShell/blob/main/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOTenantPreAuthSettings.md#feature-names)).

![image](https://github.com/user-attachments/assets/45eee64f-b8a1-4980-85e2-607c5440f508)

This is a fix for this issue and to improve formatting in all the files, as suggested by members of Ask an Admin channel.