### PR TITLE
Update Set-SPOSite.md: Update supported parameters for group sites

### DIFF
--- a/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/sharepoint-online/Set-SPOSite.md
@@ -143,7 +143,7 @@ For permissions and the most current information about Windows PowerShell for Sh
 
 For OneDrive for Business site collection, the only valid parameters are Identity, AllowDownloadingNonWebViewableFiles, AllowEditing, ConditionalAccessPolicy, DefaultLinkPermission, DefaultSharingLinkType, DisableCompanyWideSharingLinks, LimitedAccessFileType, LockState, Owner, SharingAllowedDomainList, SharingBlockedDomainList, SharingCapability, SharingDomainRestrictionMode, ShowPeoplePickerSuggestionsForGuestUsers, StorageQuota, and StorageWarningLevel.
 
-For Groups site collection, the only valid parameters are Identity, AllowSelfServiceUpgrade, DefaultLinkPermission, DefaultSharingLinkType, DenyAddAndCustomizePages, DisableCompanyWideSharingLinks, DisableSharingForNonOwners, LockState, Owner, ResourceQuota, ResourceQuotaWarningLevel, SandboxedCodeActivationCapability, SharingCapability, ShowPeoplePickerSuggestionsForGuestUsers, SocialBarOnSitePagesDisabled, StorageQuota, StorageQuotaReset, and StorageQuotaWarningLevel.
+For Groups site collection, the only valid parameters are Identity, AllowSelfServiceUpgrade, DefaultLinkPermission, DefaultSharingLinkType, DenyAddAndCustomizePages, DisableCompanyWideSharingLinks, DisableSharingForNonOwners, LockState, Owner, ResourceQuota, ResourceQuotaWarningLevel, SandboxedCodeActivationCapability, SensitivityLabel, SharingCapability, ShowPeoplePickerSuggestionsForGuestUsers, SocialBarOnSitePagesDisabled, StorageQuota, StorageQuotaReset, and StorageQuotaWarningLevel.
 
 ## EXAMPLES
 


### PR DESCRIPTION
SensitivityLabel is not included in the list of valid parameters for the group site, 

SensitivityLabel  parameter worked since at least 2022 as far as I know and I confirm that it can still be updated successfully without error.

I checked in a test tenant and the SensitivityLabel parameter works perfectly for group sites.

1) Create a group site. No sensitivity label.
![image](https://github.com/user-attachments/assets/6ce69d77-a67c-4074-bfb8-fe49229f15c2)

2) Run Set-SPOSite -identity <Site Url> -SensitivityLabel <Label GUID>. Successfully executed and reflected in the SensitivityLabel property.
![image](https://github.com/user-attachments/assets/e7801d39-4444-42ba-af26-495dce3efd98)

3) It is also reflected correctly on the site.
![image](https://github.com/user-attachments/assets/3df031ce-a207-41e9-9a5a-123c4607dc74)
