### PR TITLE
Update AutoPublish workflow to enable auto-merge of pull-requests

### DIFF
--- a/.github/workflows/AutoPublish.yml
+++ b/.github/workflows/AutoPublish.yml
@@ -3,10 +3,11 @@ name: (Scheduled) Publish to live
 permissions:
   contents: write
   pull-requests: write
+  checks: read
 
 on:
   schedule:
-    - cron: "25 5,11,17,22 * * *" # Times are UTC based on Daylight Saving Time. Need to be adjusted for Standard Time. Scheduling at :25 to account for queuing lag.
+    - cron: "25 2,5,8,11,14,17,20,22 * * *" # Times are UTC based on Daylight Saving Time. Need to be adjusted for Standard Time. Scheduling at :25 to account for queuing lag.
 
   workflow_dispatch:
 
@@ -14,10 +15,11 @@ jobs:
 
   auto-publish:
     if: github.repository_owner == 'MicrosoftDocs' && contains(github.event.repository.topics, 'build')
-    uses: MicrosoftDocs/microsoft-365-docs/.github/workflows/Shared-AutoPublish.yml@workflows-prod
+    uses: MicrosoftDocs/microsoft-365-docs/.github/workflows/Shared-AutoPublishV2.yml@workflows-prod
     with:
         PayloadJson: ${{ toJSON(github) }}
         EnableAutoPublish: true
+        EnableAutoMerge: true
 
     secrets:
         AccessToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Update AutoPublish workflow to enable auto-merge of pull-requests. Increase schedule to 8 runs per day instead of 4.