### PR TITLE
Removing -ShowDeatils parameter from Get-SPOTenant documentation

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOTenant.md
@@ -19,7 +19,7 @@ Returns SharePoint Online organization properties.
 ## SYNTAX
 
 ```
-Get-SPOTenant [-ShowDetails] [<CommonParameters>]
+Get-SPOTenant [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -43,24 +43,6 @@ Get-SPOTenant
 This example returns the organization-level site collection properties such as StorageQuota, StorageQuotaAllocated, ResourceQuota, ResourceQuotaAllocated, SiteCreationMode and OneDriveStorageQuota.
 
 ## PARAMETERS
-
-### -ShowDetails
-
-> Applicable: SharePoint Online
-
-Whether to show the detailed properties for each setting.
-
-```yaml
-Type: System.Management.Automation.SwitchParameter
-Parameter Sets: (All)
-Aliases:
-
-Required: False
-Position: Named
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
 
 ### CommonParameters
 


### PR DESCRIPTION
Updating the Get-SPOTenant documentation
- remove [ShowDetails] parameter from the cmdlet because SharePoint tenant settings feature is being removed from PS endpoint