### PR TITLE
Document SiteOwnersCanAccessMissingContent for Set-SPOTenant

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOTenant.md
@@ -5004,6 +5004,8 @@ Accept wildcard characters: False
 
 ### -SiteOwnersCanAccessMissingContent
 
+> Applicable: SharePoint Online
+
 Whether site owners can access information about missing content on their site.
 
 > [!NOTE]


### PR DESCRIPTION
Document `-SiteOwnersCanAccessMissingContent` parameter for `Set-SPOTenant` cmdlet