### PR TITLE
Revert "Add "toc_preview" and set to true"

### DIFF
--- a/sharepoint/docfx.json
+++ b/sharepoint/docfx.json
@@ -49,7 +49,6 @@
       "ms.devlang": "powershell",
       "ms.date": "09/08/2021",
       "ms.topic": "reference",
-      "toc_preview": true,
       "contributors_to_exclude": [
         "rjagiewich",
         "traya1",


### PR DESCRIPTION
This change did not achieve the desired result, and I can't find `toc_preview` in any other docfx.json file that I have cloned. 

Reverts MicrosoftDocs/OfficeDocs-SharePoint-PowerShell#1000