### PR TITLE
Correct heading markup to make articles valid

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOContainerUser.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOContainerUser.md
@@ -48,7 +48,7 @@ Example 1 assigns the role of owner to user with User Principal Name "shras@cont
 
 ## PARAMETERS
 
--ContainerId
+### -ContainerId
 
 > Applicable: SharePoint Online
 
@@ -66,7 +66,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
--LoginName
+### -LoginName
 
 > Applicable: SharePoint Online
 
@@ -84,7 +84,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
--Role
+### -Role
 
 > Applicable: SharePoint Online
 
@@ -110,6 +110,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
@@ -133,7 +134,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 [Set-SPOContainer](./Set-SPOContainer.md)
 
 [Get-SPOContainer](./Get-SPOContainer.md)
-
-
-
-

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOContainerUser.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOContainerUser.md
@@ -22,7 +22,7 @@ Adds a user to a SharePoint Embedded container with a specified role.
 Add-SPOContainerUser [-ContainerId] <String> -LoginName <String> -Role <String> [<CommonParameters>]
 ```
 
-##DESCRIPTION
+## DESCRIPTION
 
 Assigns a user to a defined role within a SharePoint Embedded container.
 

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOContainerUser.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOContainerUser.md
@@ -22,7 +22,7 @@ Removes a user from a specified role in a SharePoint Embedded container.
 Remove-SPOContainerUser [-ContainerId] <String> -LoginName <String> -Role <String> [<CommonParameters>]
 ```
 
-##DESCRIPTION
+## DESCRIPTION
 
 Removes a user from a defined role within a SharePoint Embedded container.
 

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOContainerUser.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOContainerUser.md
@@ -46,7 +46,7 @@ Example 1 removes the user with User Principal Name "shras@contoso.com" from the
 
 ## PARAMETERS
 
--ContainerId
+### -ContainerId
 
 > Applicable: SharePoint Online
 
@@ -64,7 +64,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
--LoginName
+### -LoginName
 
 > Applicable: SharePoint Online
 
@@ -82,7 +82,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
--Role
+### -Role
 
 > Applicable: SharePoint Online
 
@@ -108,6 +108,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOContainerUser.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOContainerUser.md
@@ -22,7 +22,7 @@ Reassigns a user from their current role to a new role within a SharePoint Embed
 Set-SPOContainerUser [-ContainerId] <String> -LoginName <String> -Role <String> [<CommonParameters>
 ```
 
-##DESCRIPTION
+## DESCRIPTION
 
 Updates a user's assigned role within a SharePoint Embedded container.
 

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOContainerUser.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOContainerUser.md
@@ -47,7 +47,7 @@ Example 1 reassigns the role of User Principal Name "shras@contoso.com" to manag
 
 ## PARAMETERS
 
--ContainerId
+### -ContainerId
 
 > Applicable: SharePoint Online
 
@@ -65,7 +65,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
--LoginName
+### -LoginName
 
 > Applicable: SharePoint Online
 
@@ -83,7 +83,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
--Role
+### -Role
 
 > Applicable: SharePoint Online
 
@@ -109,6 +109,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
+
 This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS


### PR DESCRIPTION
Without a space between the heading identifier and the heading, the build system doesn't recognize the section