### PR TITLE
Update LegacyBrowserAuthProtocolsEnabled setting to reflect the ongoing deprecation

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOTenant.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOTenant.md
@@ -3698,6 +3698,9 @@ Controls whether legacy browser authentication connections to SharePoint with le
 
 PARAMVALUE: True | False
 
+> [!NOTE]
+> • Legacy browser authentication is being deprecated for enterprise tenants as of October 2025. <br/> This setting will no longer be available to set to true. The RPS protocol will no longer function. <br/>
+
 ```yaml
 Type: System.Boolean
 Parameter Sets: (All)


### PR DESCRIPTION
This PR adds a note to the LegacyBrowserAuthProtocolsEnabled that warns that the protocol is being deprecated in Oct 2025 and will no longer be available. Since the deprecation is multiple phases, and not all customers will be blocked until late 2026, we cannot yet completely remove the setting, but will once possible. 