### PR TITLE
Update Get-SPOApplication and Set-SPOApplication with MajorVersionLimit

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOApplication.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOApplication.md
@@ -100,6 +100,8 @@ The following details are returned:
 
 - CopilotEmbeddedChatHosts
 
+- MajorVersionLimit
+
 ```yaml
 Type: System.Guid
 Parameter Sets: (All)

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
@@ -70,6 +70,13 @@ Set-SPOApplication -OwningApplicationId 423poi45 -CopilotEmbeddedChatHosts "http
 ```
 This example sets the host URLs for the application with Id 423poi45.
 
+### Example 5
+
+```powershell
+Set-SPOApplication -OwningApplicationId 423poi45 -MajorVersionLimit 1000
+```
+This example sets the MajorVersionLimit to 1000
+
 ## PARAMETERS
 
 ### -CopilotEmbeddedChatHosts

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
@@ -75,7 +75,7 @@ This example sets the host URLs for the application with Id 423poi45.
 ```powershell
 Set-SPOApplication -OwningApplicationId 423poi45 -MajorVersionLimit 1000
 ```
-This example sets the MajorVersionLimit to 1000
+This example sets the MajorVersionLimit to 1000.
 
 ## PARAMETERS
 

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
@@ -132,7 +132,7 @@ Accept wildcard characters: False
 
 ### -MajorVersionLimit
 
-This parameter is used to override MajorVerisonLimit for 1P container types.
+This parameter is used to override MajorVerisonLimit for first-party container types.
 
 ```yaml
 Type: Int

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
@@ -21,6 +21,7 @@ Sets or updates one or more configuration of a SharePoint Embedded application.
 Set-SPOApplication [-OwningApplicationId] <Guid> [[-SharingCapability] <SharingCapabilities>]
  [[-OverrideTenantSharingCapability] <Boolean>]
  [[-CopilotEmbeddedChatHosts] <System.Collections.Generic.List`1[System.String]>]
+ [[-MajorVersionLimit] <Int>]
  [<CommonParameters>]
 ```
 

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
@@ -132,7 +132,7 @@ Accept wildcard characters: False
 
 ### -MajorVersionLimit
 
-This parameter is used to override MajorVerisonLimit for first-party container types.
+This parameter is used to override MajorVersionLimit for first-party container types.
 
 ```yaml
 Type: Int

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOApplication.md
@@ -130,6 +130,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -MajorVersionLimit
+
+This parameter is used to override MajorVerisonLimit for 1P container types.
+
+```yaml
+Type: Int
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -SharingCapability
 
 Determines what level of sharing is available for the SharePoint Embedded Application.


### PR DESCRIPTION
MajorVersionLimit can be retrieved and set with Get-SPOApplication and Set-SPOApplication.

Related SPO.Core PR: [Pull Request 2184111](https://dev.azure.com/onedrive/SharePoint%20Online/_git/SPO.Core/pullrequest/2184111): MajorVersionLimit on Set-SPOApplication/Get-SPOApplication