### PR TITLE
Add -AuditOnly parameter to Set-SPORestrictedSiteCreationForApps

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPORestrictedSiteCreationForApps.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPORestrictedSiteCreationForApps.md
@@ -138,6 +138,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -AuditOnly
+
+> Applicable: SharePoint Online
+
+Shows what would happen if the cmdlet runs without enforcing the policy by only giving audit events when site creation is restricted.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -SiteType
 
 > Applicable: SharePoint Online


### PR DESCRIPTION
Added -AuditOnly parameter to cmdlet documentation to indicate its behavior when site creation is restricted.