### PR TITLE
Add document for Set-SPOCustomFontCatalog

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Microsoft.Online.SharePoint.PowerShell.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Microsoft.Online.SharePoint.PowerShell.md
@@ -719,6 +719,9 @@ Adds the email addresses to the specified category of content event. Consequentl
 ### [Set-SPOCopilotPromoOptInStatus](Set-SPOCopilotPromoOptInStatus.md)
 Sets the Opt-In Copilot promo status for the tenant.
 
+### [Set-SPOCustomFontCatalog](Set-SPOCustomFontCatalog.md)
+Generates an organization fonts catalog and uploads the font files and catalog files to a SharePoint Organization Asset Library.
+
 ### [Set-SPOCrossTenantRelationship](Set-SPOCrossTenantRelationship.md)
 This cmdlet sends a trust request to the tenant with whom you want to establish trust.
 

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOCustomFontCatalog.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOCustomFontCatalog.md
@@ -5,6 +5,8 @@ online version: https://learn.microsoft.com/powershell/module/microsoft.online.s
 applicable: SharePoint Online
 title: Set-SPOCustomFontCatalog
 schema: 2.0.0
+author: reli-msft
+ms.author: reli
 ---
 
 # Set-SPOCustomFontCatalog
@@ -22,20 +24,22 @@ Set-SPOCustomFontCatalog -LibraryUrl <SpoSitePipeBind> -FontFolder <String> [-Wh
 
 ## DESCRIPTION
 
-The `Set-SPOCustomFontCatalog` cmdlet generates the catalog files that make organization fonts available in supported Microsoft 365 apps, including PowerPoint and Word, and uploads the catalog files and font files to a SharePoint Organization Asset Library.
+This cmdlet generates the catalog files that make organization fonts available in supported Microsoft 365 apps, including PowerPoint and Word, and uploads the catalog files and font files to a SharePoint organization asset library.
 
-Before you run this cmdlet, designate the target document library as an Organization Asset Library for organization fonts by running `Add-SPOOrgAssetsLibrary` with `-OrgAssetType OfficeFontLibrary` and `-CdnType Public`.
+Before you use this cmdlet, designate the target document library as an organization asset library for organization fonts by using `Add-SPOOrgAssetsLibrary` with `-OrgAssetType OfficeFontLibrary` and `-CdnType Public`.
 
-The local font folder must contain the complete set of font files that you want published. The folder must be local, must not contain subfolders, and must only contain font files. To add, update, or remove fonts later, update the local folder so it contains the complete desired set of fonts, including unchanged fonts, and then run this cmdlet again.
+The local font folder must contain the complete set of font files that you want to publish. The folder must be local, must not contain subfolders, and must contain only font files. To add, update, or remove fonts later, update the local folder so that it contains the complete desired set of fonts, including unchanged fonts, and then run this cmdlet again.
 
-Updates to Organization Asset Libraries for organization fonts can take up to 24 hours to propagate.
+Updates to organization asset libraries for organization fonts can take up to 24 hours to propagate.
 
 > [!WARNING]
-> By using this feature and publishing font files, a font catalog file will be created. The newly created font catalog files will be publicly stored, along with the fonts, in the cloud and will not respect the site classification guidelines if the Organization Asset Library is hosted on a Restricted SharePoint Site. The font catalog files will contain font names and other font-related metadata. Please note that the files will be accessible to anyone, including persons external to your organization, who are able to extract the URLs that point to them.
+> By using this feature and publishing font files, a font catalog file is created. The font catalog files and font files are stored publicly in the cloud and don't respect site classification guidelines if the organization asset library is hosted on a restricted SharePoint site.
 >
-> These newly created files can be deleted by you. If deleted, the feature will not work as expected.
+> The font catalog files contain font names and other font metadata. These files are accessible to anyone, including people outside your organization, who can obtain the URLs that point to them.
 >
-> Do not use this feature if your fonts contain proprietary information, or if they have license usage restrictions, such as restrictions on cloud hosting, or if your organization isn't comfortable making the fonts publicly available.
+> You can delete these files. However, deleting them prevents the feature from working as expected.
+>
+> Don't use this feature if your fonts contain proprietary information, have license restrictions such as restrictions on cloud hosting, or if your organization isn't comfortable making the fonts publicly available.
 
 ## EXAMPLES
 
@@ -142,7 +146,7 @@ Accept wildcard characters: False
 
 ### CommonParameters
 
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOCustomFontCatalog.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOCustomFontCatalog.md
@@ -1,0 +1,169 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version: https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/set-spocustomfontcatalog
+applicable: SharePoint Online
+title: Set-SPOCustomFontCatalog
+schema: 2.0.0
+---
+
+# Set-SPOCustomFontCatalog
+
+## SYNOPSIS
+
+Generates an organization fonts catalog and uploads the font files and catalog files to a SharePoint Organization Asset Library.
+
+## SYNTAX
+
+```
+Set-SPOCustomFontCatalog -LibraryUrl <SpoSitePipeBind> -FontFolder <String> [-WhatIf] [-Confirm]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The `Set-SPOCustomFontCatalog` cmdlet generates the catalog files that make organization fonts available in supported Microsoft 365 apps, including PowerPoint and Word, and uploads the catalog files and font files to a SharePoint Organization Asset Library.
+
+Before you run this cmdlet, designate the target document library as an Organization Asset Library for organization fonts by running `Add-SPOOrgAssetsLibrary` with `-OrgAssetType OfficeFontLibrary` and `-CdnType Public`.
+
+The local font folder must contain the complete set of font files that you want published. The folder must be local, must not contain subfolders, and must only contain font files. To add, update, or remove fonts later, update the local folder so it contains the complete desired set of fonts, including unchanged fonts, and then run this cmdlet again.
+
+Updates to Organization Asset Libraries for organization fonts can take up to 24 hours to propagate.
+
+> [!WARNING]
+> By using this feature and publishing font files, a font catalog file will be created. The newly created font catalog files will be publicly stored, along with the fonts, in the cloud and will not respect the site classification guidelines if the Organization Asset Library is hosted on a Restricted SharePoint Site. The font catalog files will contain font names and other font-related metadata. Please note that the files will be accessible to anyone, including persons external to your organization, who are able to extract the URLs that point to them.
+>
+> These newly created files can be deleted by you. If deleted, the feature will not work as expected.
+>
+> Do not use this feature if your fonts contain proprietary information, or if they have license usage restrictions, such as restrictions on cloud hosting, or if your organization isn't comfortable making the fonts publicly available.
+
+## EXAMPLES
+
+### Example 1
+
+```powershell
+Add-SPOOrgAssetsLibrary -LibraryUrl https://contoso.sharepoint.com/sites/branding/FontLibrary -OrgAssetType OfficeFontLibrary -CdnType Public
+Set-SPOCustomFontCatalog -FontFolder "C:\ContosoFonts" -LibraryUrl https://contoso.sharepoint.com/sites/branding/FontLibrary
+```
+
+This example designates the FontLibrary document library as an Organization Asset Library for organization fonts and uploads the fonts from `C:\ContosoFonts` with the generated font catalog files.
+
+### Example 2
+
+```powershell
+Set-SPOCustomFontCatalog -FontFolder "C:\ContosoFonts" -LibraryUrl https://contoso.sharepoint.com/sites/branding/FontLibrary
+```
+
+This example replaces the published organization font set with the complete set of fonts in `C:\ContosoFonts`.
+
+### Example 3
+
+```powershell
+Set-SPOCustomFontCatalog -FontFolder "C:\ContosoFonts" -LibraryUrl https://contoso.sharepoint.com/sites/branding/FontLibrary -Verbose
+```
+
+This example uploads the fonts and displays additional font validation details and font menu previews.
+
+## PARAMETERS
+
+### -Confirm
+
+> Applicable: SharePoint Online
+
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FontFolder
+
+> Applicable: SharePoint Online
+
+Specifies the local folder that contains the font files to upload. The folder must be a local path, must contain at least one supported font file, must not contain subfolders, and must only contain font files.
+
+```yaml
+Type: System.String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LibraryUrl
+
+> Applicable: SharePoint Online
+
+Specifies the absolute URL of the SharePoint document library that is designated as an Organization Asset Library for organization fonts. The library must be added by using `Add-SPOOrgAssetsLibrary -OrgAssetType OfficeFontLibrary -CdnType Public`.
+
+Only include the direct path to the document library. Don't include a view page, such as `/AllItems.aspx`.
+
+```yaml
+Type: Microsoft.Online.SharePoint.PowerShell.SpoSitePipeBind
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+
+> Applicable: SharePoint Online
+
+Shows what would happen if the cmdlet runs. Note that the cmdlet is not actually run.
+
+```yaml
+Type: System.Management.Automation.SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+
+## NOTES
+
+You may be prompted to enter your credentials again during upload.
+
+Use the `-Verbose` common parameter to show additional non-blocking font validation information and font menu previews. Verbose output can include validation warnings, informational messages about font characteristics, and previews of how font families and faces will appear in Office font menus.
+
+## RELATED LINKS
+
+[Add-SPOOrgAssetsLibrary](Add-SPOOrgAssetsLibrary.md)
+
+[Get-SPOOrgAssetsLibrary](Get-SPOOrgAssetsLibrary.md)
+
+[Remove-SPOOrgAssetsLibrary](Remove-SPOOrgAssetsLibrary.md)
+
+[Support for organization fonts in PowerPoint and Word](/sharepoint/support-for-organization-fonts-in-powerpoint-for-the-web)


### PR DESCRIPTION
Adds standalone documentation for the `Set-SPOCustomFontCatalog` SharePoint Online PowerShell cmdlet.

The new page documents how to generate the organization fonts catalog and upload font/catalog files to an Organization Asset Library, including prerequisites, font folder requirements, examples, parameters' details, the public CDN/licensing warning, and related links. This also adds the cmdlet to the module cmdlet index.

