### PR TITLE
Add File Archive Policy cmdlet documentation

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
@@ -1,14 +1,20 @@
 ---
 external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/add-spositetofilearchivepolicy
+applicable: SharePoint Online
+title: Add-SPOSiteToFileArchivePolicy
 schema: 2.0.0
+author: HectorRMota
+ms.author: hemota
+ms.reviewer:
 ---
 
 # Add-SPOSiteToFileArchivePolicy
 
 ## SYNOPSIS
-Adds a site to a File Archive Policy.
+
+Adds a site to a file archive policy.
 
 ## SYNTAX
 
@@ -17,22 +23,26 @@ Add-SPOSiteToFileArchivePolicy -PolicyId <Guid> -Site <SpoSitePipeBind> [<Common
 ```
 
 ## DESCRIPTION
-The `Add-SPOSiteToFileArchivePolicy` cmdlet adds a site to an existing File Archive Policy that has a PolicyType of "SelectedSites". The site must exist and be eligible for archiving. At least one site must be added before a "SelectedSites" policy can be activated.
 
-You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+This cmdlet adds a site to an existing file archive policy that has a PolicyType of "SelectedSites". The site must exist and be eligible for archiving. At least one site must be added before a "SelectedSites" policy can be activated.
+
+> [!NOTE]
+> This cmdlet is part of the file archive policies feature which is currently in preview.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-PS C:\> Add-SPOSiteToFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Site "https://contoso.sharepoint.com/sites/marketing"
+Add-SPOSiteToFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Site "https://contoso.sharepoint.com/sites/marketing"
 ```
 
-Adds the marketing site to the specified File Archive Policy.
+Adds the marketing site to the specified file archive policy.
 
 ## PARAMETERS
 
 ### -PolicyId
+
 Specifies the unique identifier (GUID) of the policy to add the site to.
 
 ```yaml
@@ -48,7 +58,8 @@ Accept wildcard characters: False
 ```
 
 ### -Site
-Specifies the URL of the site to add to the policy (e.g., "https://contoso.sharepoint.com/sites/marketing"). The site must exist and be eligible for archiving.
+
+Specifies the URL of the site to add to the policy. The site must exist and be eligible for archiving.
 
 ```yaml
 Type: SpoSitePipeBind
@@ -63,7 +74,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -72,8 +84,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-## NOTES
 
-This cmdlet is part of the File Archive Policies feature which is currently in preview.
+## NOTES
 
 ## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
@@ -1,0 +1,79 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Add-SPOSiteToFileArchivePolicy
+
+## SYNOPSIS
+Adds a site to a File Archive Policy.
+
+## SYNTAX
+
+```
+Add-SPOSiteToFileArchivePolicy -PolicyId <Guid> -Site <SpoSitePipeBind> [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `Add-SPOSiteToFileArchivePolicy` cmdlet adds a site to an existing File Archive Policy that has a PolicyType of "SelectedSites". The site must exist and be eligible for archiving. At least one site must be added before a "SelectedSites" policy can be activated.
+
+You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Add-SPOSiteToFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Site "https://contoso.sharepoint.com/sites/marketing"
+```
+
+Adds the marketing site to the specified File Archive Policy.
+
+## PARAMETERS
+
+### -PolicyId
+Specifies the unique identifier (GUID) of the policy to add the site to.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Site
+Specifies the URL of the site to add to the policy (e.g., "https://contoso.sharepoint.com/sites/marketing"). The site must exist and be eligible for archiving.
+
+```yaml
+Type: SpoSitePipeBind
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+This cmdlet is part of the File Archive Policies feature which is currently in preview.
+
+## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
@@ -24,7 +24,7 @@ Add-SPOSiteToFileArchivePolicy -PolicyId <Guid> -Site <SpoSitePipeBind> [<Common
 
 ## DESCRIPTION
 
-This cmdlet adds a site to an existing file archive policy that has a PolicyType of "SelectedSites". The site must exist and be eligible for archiving. At least one site must be added before a "SelectedSites" policy can be activated.
+This cmdlet adds a site to an existing file archive policy that has a PolicyType of `SelectedSites`. The site must exist and be eligible for archiving. At least one site must be added before a `SelectedSites` policy can be activated.
 
 > [!NOTE]
 > This cmdlet is part of the file archive policies feature which is currently in preview.

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
@@ -88,3 +88,17 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## NOTES
 
 ## RELATED LINKS
+
+[Get-SPOFileArchivePolicy](Get-SPOFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicyReport](Get-SPOFileArchivePolicyReport.md)
+
+[Get-SPOFileArchivePolicySites](Get-SPOFileArchivePolicySites.md)
+
+[New-SPOFileArchivePolicy](New-SPOFileArchivePolicy.md)
+
+[Remove-SPOFileArchivePolicy](Remove-SPOFileArchivePolicy.md)
+
+[Remove-SPOSiteToFileArchivePolicy](Remove-SPOSiteToFileArchivePolicy.md)
+
+[Set-SPOFileArchivePolicy](Set-SPOFileArchivePolicy.md)

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicy.md
@@ -1,0 +1,71 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Get-SPOFileArchivePolicy
+
+## SYNOPSIS
+Gets one or all File Archive Policies for the tenant.
+
+## SYNTAX
+
+```
+Get-SPOFileArchivePolicy [-PolicyId <Guid>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `Get-SPOFileArchivePolicy` cmdlet retrieves the properties of File Archive Policies for the connected SharePoint Online tenant. If the `-PolicyId` parameter is specified, returns only the matching policy. If omitted, returns all File Archive Policies under the tenant.
+
+You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-SPOFileArchivePolicy
+```
+
+Returns all File Archive Policies configured for the tenant.
+
+### Example 2
+```powershell
+PS C:\> Get-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+```
+
+Returns the File Archive Policy with the specified ID.
+
+## PARAMETERS
+
+### -PolicyId
+Specifies the unique identifier (GUID) of the policy to retrieve. If not specified, all policies under the tenant are returned.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+This cmdlet is part of the File Archive Policies feature which is currently in preview.
+
+## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicy.md
@@ -1,14 +1,20 @@
 ---
 external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/get-spofilearchivepolicy
+applicable: SharePoint Online
+title: Get-SPOFileArchivePolicy
 schema: 2.0.0
+author: HectorRMota
+ms.author: hemota
+ms.reviewer:
 ---
 
 # Get-SPOFileArchivePolicy
 
 ## SYNOPSIS
-Gets one or all File Archive Policies for the tenant.
+
+Gets one or all file archive policies for the tenant.
 
 ## SYNTAX
 
@@ -17,29 +23,34 @@ Get-SPOFileArchivePolicy [-PolicyId <Guid>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The `Get-SPOFileArchivePolicy` cmdlet retrieves the properties of File Archive Policies for the connected SharePoint Online tenant. If the `-PolicyId` parameter is specified, returns only the matching policy. If omitted, returns all File Archive Policies under the tenant.
 
-You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+This cmdlet retrieves the properties of file archive policies for the connected SharePoint Online tenant. If the `-PolicyId` parameter is specified, returns only the matching policy. If omitted, returns all file archive policies under the tenant.
+
+> [!NOTE]
+> This cmdlet is part of the file archive policies feature which is currently in preview.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-PS C:\> Get-SPOFileArchivePolicy
+Get-SPOFileArchivePolicy
 ```
 
-Returns all File Archive Policies configured for the tenant.
+Returns all file archive policies configured for the tenant.
 
 ### Example 2
+
 ```powershell
-PS C:\> Get-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+Get-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 ```
 
-Returns the File Archive Policy with the specified ID.
+Returns the file archive policy with the specified ID.
 
 ## PARAMETERS
 
 ### -PolicyId
+
 Specifies the unique identifier (GUID) of the policy to retrieve. If not specified, all policies under the tenant are returned.
 
 ```yaml
@@ -55,7 +66,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -64,8 +76,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-## NOTES
 
-This cmdlet is part of the File Archive Policies feature which is currently in preview.
+## NOTES
 
 ## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicy.md
@@ -80,3 +80,17 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## NOTES
 
 ## RELATED LINKS
+
+[Add-SPOSiteToFileArchivePolicy](Add-SPOSiteToFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicyReport](Get-SPOFileArchivePolicyReport.md)
+
+[Get-SPOFileArchivePolicySites](Get-SPOFileArchivePolicySites.md)
+
+[New-SPOFileArchivePolicy](New-SPOFileArchivePolicy.md)
+
+[Remove-SPOFileArchivePolicy](Remove-SPOFileArchivePolicy.md)
+
+[Remove-SPOSiteToFileArchivePolicy](Remove-SPOSiteToFileArchivePolicy.md)
+
+[Set-SPOFileArchivePolicy](Set-SPOFileArchivePolicy.md)

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicyReport.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicyReport.md
@@ -74,3 +74,17 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## NOTES
 
 ## RELATED LINKS
+
+[Add-SPOSiteToFileArchivePolicy](Add-SPOSiteToFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicy](Get-SPOFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicySites](Get-SPOFileArchivePolicySites.md)
+
+[New-SPOFileArchivePolicy](New-SPOFileArchivePolicy.md)
+
+[Remove-SPOFileArchivePolicy](Remove-SPOFileArchivePolicy.md)
+
+[Remove-SPOSiteToFileArchivePolicy](Remove-SPOSiteToFileArchivePolicy.md)
+
+[Set-SPOFileArchivePolicy](Set-SPOFileArchivePolicy.md)

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicyReport.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicyReport.md
@@ -1,14 +1,20 @@
 ---
 external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/get-spofilearchivepolicyreport
+applicable: SharePoint Online
+title: Get-SPOFileArchivePolicyReport
 schema: 2.0.0
+author: HectorRMota
+ms.author: hemota
+ms.reviewer:
 ---
 
 # Get-SPOFileArchivePolicyReport
 
 ## SYNOPSIS
-Gets run reports for a File Archive Policy.
+
+Gets run reports for a file archive policy.
 
 ## SYNTAX
 
@@ -17,24 +23,28 @@ Get-SPOFileArchivePolicyReport -PolicyId <Guid> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The `Get-SPOFileArchivePolicyReport` cmdlet retrieves the run reports for a File Archive Policy. Reports are kept for the past 12 months and include details about each policy run such as how many sites were processed, how many files were archived, and the total storage archived.
 
-For policies running in WhatIf mode, reports show how many files and how much storage would have been archived instead.
+This cmdlet retrieves the run reports for a file archive policy. Reports are kept for the past 12 months and include details about each policy run such as how many sites were processed, how many files were archived, and the total storage archived.
 
-You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+For policies running in `WhatIf` mode, reports show how many files and how much storage would have been archived instead.
+
+> [!NOTE]
+> This cmdlet is part of the file archive policies feature which is currently in preview.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-PS C:\> Get-SPOFileArchivePolicyReport -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+Get-SPOFileArchivePolicyReport -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 ```
 
-Returns all run reports for the specified File Archive Policy from the past 12 months.
+Returns all run reports for the specified file archive policy from the past 12 months.
 
 ## PARAMETERS
 
 ### -PolicyId
+
 Specifies the unique identifier (GUID) of the policy to retrieve run reports for.
 
 ```yaml
@@ -50,7 +60,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -59,8 +70,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-## NOTES
 
-This cmdlet is part of the File Archive Policies feature which is currently in preview.
+## NOTES
 
 ## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicyReport.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicyReport.md
@@ -1,0 +1,66 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Get-SPOFileArchivePolicyReport
+
+## SYNOPSIS
+Gets run reports for a File Archive Policy.
+
+## SYNTAX
+
+```
+Get-SPOFileArchivePolicyReport -PolicyId <Guid> [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `Get-SPOFileArchivePolicyReport` cmdlet retrieves the run reports for a File Archive Policy. Reports are kept for the past 12 months and include details about each policy run such as how many sites were processed, how many files were archived, and the total storage archived.
+
+For policies running in WhatIf mode, reports show how many files and how much storage would have been archived instead.
+
+You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-SPOFileArchivePolicyReport -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+```
+
+Returns all run reports for the specified File Archive Policy from the past 12 months.
+
+## PARAMETERS
+
+### -PolicyId
+Specifies the unique identifier (GUID) of the policy to retrieve run reports for.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+This cmdlet is part of the File Archive Policies feature which is currently in preview.
+
+## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
@@ -1,14 +1,20 @@
 ---
 external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/get-spofilearchivepolicysites
+applicable: SharePoint Online
+title: Get-SPOFileArchivePolicySites
 schema: 2.0.0
+author: HectorRMota
+ms.author: hemota
+ms.reviewer:
 ---
 
 # Get-SPOFileArchivePolicySites
 
 ## SYNOPSIS
-Gets the list of sites associated with a File Archive Policy.
+
+Gets the list of sites associated with a file archive policy.
 
 ## SYNTAX
 
@@ -17,22 +23,26 @@ Get-SPOFileArchivePolicySites -PolicyId <Guid> [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-The `Get-SPOFileArchivePolicySites` cmdlet retrieves the list of sites that have been added to a File Archive Policy. This is applicable to policies with a PolicyType of "SelectedSites".
 
-You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+This cmdlet retrieves the list of sites that have been added to a file archive policy. This is applicable to policies with a PolicyType of "SelectedSites".
+
+> [!NOTE]
+> This cmdlet is part of the file archive policies feature which is currently in preview.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-PS C:\> Get-SPOFileArchivePolicySites -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+Get-SPOFileArchivePolicySites -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 ```
 
-Returns all sites associated with the specified File Archive Policy.
+Returns all sites associated with the specified file archive policy.
 
 ## PARAMETERS
 
 ### -PolicyId
+
 Specifies the unique identifier (GUID) of the policy to retrieve the site list for.
 
 ```yaml
@@ -48,7 +58,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -57,8 +68,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-## NOTES
 
-This cmdlet is part of the File Archive Policies feature which is currently in preview.
+## NOTES
 
 ## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
@@ -72,3 +72,17 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## NOTES
 
 ## RELATED LINKS
+
+[Add-SPOSiteToFileArchivePolicy](Add-SPOSiteToFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicy](Get-SPOFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicyReport](Get-SPOFileArchivePolicyReport.md)
+
+[New-SPOFileArchivePolicy](New-SPOFileArchivePolicy.md)
+
+[Remove-SPOFileArchivePolicy](Remove-SPOFileArchivePolicy.md)
+
+[Remove-SPOSiteToFileArchivePolicy](Remove-SPOSiteToFileArchivePolicy.md)
+
+[Set-SPOFileArchivePolicy](Set-SPOFileArchivePolicy.md)

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
@@ -1,0 +1,64 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Get-SPOFileArchivePolicySites
+
+## SYNOPSIS
+Gets the list of sites associated with a File Archive Policy.
+
+## SYNTAX
+
+```
+Get-SPOFileArchivePolicySites -PolicyId <Guid> [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `Get-SPOFileArchivePolicySites` cmdlet retrieves the list of sites that have been added to a File Archive Policy. This is applicable to policies with a PolicyType of "SelectedSites".
+
+You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Get-SPOFileArchivePolicySites -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+```
+
+Returns all sites associated with the specified File Archive Policy.
+
+## PARAMETERS
+
+### -PolicyId
+Specifies the unique identifier (GUID) of the policy to retrieve the site list for.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+This cmdlet is part of the File Archive Policies feature which is currently in preview.
+
+## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
@@ -24,7 +24,7 @@ Get-SPOFileArchivePolicySites -PolicyId <Guid> [<CommonParameters>]
 
 ## DESCRIPTION
 
-This cmdlet retrieves the list of sites that have been added to a file archive policy. This is applicable to policies with a PolicyType of "SelectedSites".
+This cmdlet retrieves the list of sites that have been added to a file archive policy. This is applicable to policies with a PolicyType of `SelectedSites`.
 
 > [!NOTE]
 > This cmdlet is part of the file archive policies feature which is currently in preview.

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Microsoft.Online.SharePoint.PowerShell.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Microsoft.Online.SharePoint.PowerShell.md
@@ -65,6 +65,9 @@ Uploads a new site script for use either directly or in a site design.
 ### [Add-SPOSiteScriptPackage](Add-SPOSiteScriptPackage.md)
 Uploads a new site script package for use either directly or in a site design.
 
+### [Add-SPOSiteToFileArchivePolicy](Add-SPOSiteToFileArchivePolicy.md)
+Adds a site to a File Archive Policy.
+
 ### [Add-SPOTenantCdnOrigin](Add-SPOTenantCdnOrigin.md)
 Configures a new origin to public or private content delivery network (CDN). Requires Tenant administrator permissions.
 
@@ -208,6 +211,15 @@ This cmdlet enables the administrator to check status of all active and availabl
 
 ### [Get-SPOExternalUser](Get-SPOExternalUser.md)
 Returns external users in the tenant.
+
+### [Get-SPOFileArchivePolicy](Get-SPOFileArchivePolicy.md)
+Gets one or all File Archive Policies for the tenant.
+
+### [Get-SPOFileArchivePolicyReport](Get-SPOFileArchivePolicyReport.md)
+Gets run reports for a File Archive Policy.
+
+### [Get-SPOFileArchivePolicySites](Get-SPOFileArchivePolicySites.md)
+Gets the list of sites associated with a File Archive Policy.
 
 ### [Get-SPOFileRequestBrandingProfiles](Get-SPOFileRequestBrandingProfiles.md)
 Retrieves branding profiles configured for the file request feature, including details about logo and background assets.
@@ -464,6 +476,9 @@ Creates a new billing policy for an application owned by the tenant.
 ### [New-SPOContainerType](New-SPOContainerType.md)
 This cmdlet creates a new container type of standard or trial status. The standard container type can be created with the regular billing structure or direct to customer billing structure.
 
+### [New-SPOFileArchivePolicy](New-SPOFileArchivePolicy.md)
+Creates a new File Archive Policy for the tenant.
+
 ### [New-SPOListFileVersionBatchDeleteJob](New-SPOListFileVersionBatchDeleteJob.md)
 Queues a job to trim versions from a document library.
 
@@ -542,6 +557,9 @@ Removes a SharePoint Online deleted site collection from the Recycle Bin.
 ### [Remove-SPOExternalUser](Remove-SPOExternalUser.md)
 Removes a collection of external users from the tenancy's folder.
 
+### [Remove-SPOFileArchivePolicy](Remove-SPOFileArchivePolicy.md)
+Removes (soft-deletes) a File Archive Policy.
+
 ### [Remove-SPOFileRequestBrandingProfile](Remove-SPOFileRequestBrandingProfile.md)
 Removes a branding profile (either primary or secondary) configured for the file request feature across the tenant.
 
@@ -619,6 +637,9 @@ Stops processing of the in-progress manage version policy job for the given site
 
 ### [Remove-SPOSiteScript](Remove-SPOSiteScript.md)
 Removes a site script.
+
+### [Remove-SPOSiteToFileArchivePolicy](Remove-SPOSiteToFileArchivePolicy.md)
+Removes a site from a File Archive Policy.
 
 ### [Remove-SPOSiteUserInvitations](Remove-SPOSiteUserInvitations.md)
 .
@@ -727,6 +748,9 @@ This cmdlet sends a trust request to the tenant with whom you want to establish 
 
 ### [Set-SPODisableSpacesActivation](Set-SPODisableSpacesActivation.md)
 Disables the SharePoint Spaces activation.
+
+### [Set-SPOFileArchivePolicy](Set-SPOFileArchivePolicy.md)
+Updates an existing File Archive Policy.
 
 ### [Set-SPOFontPackage](Set-SPOFontPackage.md)
 Applies a brand font package to a SharePoint site or Viva Connections.

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
@@ -1,0 +1,140 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# New-SPOFileArchivePolicy
+
+## SYNOPSIS
+Creates a new File Archive Policy for the tenant.
+
+## SYNTAX
+
+```
+New-SPOFileArchivePolicy [-Name <String>] -PolicyType <String> [-LastAccessDateCriteria <Int32>]
+ [-FileTypeCriteria <String[]>] [-IsWhatIfMode <Boolean>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `New-SPOFileArchivePolicy` cmdlet creates a new File Archive Policy for the connected SharePoint Online tenant. A File Archive Policy defines the criteria under which files are automatically archived based on their last access date. The policy is created in an Inactive state and must be activated using `Set-SPOFileArchivePolicy` before it takes effect.
+
+You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> New-SPOFileArchivePolicy -PolicyType "AllSites" -Name "ArchiveAll"
+```
+
+Creates a new File Archive Policy named "ArchiveAll" that targets all sites in the tenant, using the default last access date criteria of 24 months.
+
+### Example 2
+```powershell
+PS C:\> New-SPOFileArchivePolicy -PolicyType "SelectedSites" -Name "ArchiveMarketing" -LastAccessDateCriteria 12 -FileTypeCriteria ".docx", ".pptx", ".xlsx"
+```
+
+Creates a new File Archive Policy named "ArchiveMarketing" that targets selected sites, archives files not accessed in the last 12 months, and only applies to .docx, .pptx, and .xlsx file types.
+
+### Example 3
+```powershell
+PS C:\> New-SPOFileArchivePolicy -PolicyType "AllSites" -IsWhatIfMode $true
+```
+
+Creates a new File Archive Policy in WhatIf mode. When the policy runs, it will report which files would be archived without actually archiving them.
+
+## PARAMETERS
+
+### -FileTypeCriteria
+Specifies an array of file extensions to include in the policy. Only files matching the specified extensions will be considered for archiving. Use the dot-prefixed format (e.g., ".docx", ".pdf"). If not specified, all file types are included.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsWhatIfMode
+Specifies whether the policy runs in WhatIf mode. When set to `$true`, the policy will evaluate which files meet the archiving criteria and report the results, but will not actually archive any files. When set to `$false` or not specified, the policy archives files normally when active.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LastAccessDateCriteria
+Specifies the number of months since a file was last accessed before it becomes eligible for archiving. Valid values range from 6 to 48. The default value is 24 months. Note: the last access date is accurate starting July 2025.  Dates before that may be missing access signals from some clients.  For critical data, ensure your criteria doesn't archive based on last access dates before July 2025. 
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies a display name for the policy. If not specified, defaults to "MyPolicy".
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PolicyType
+Specifies whether the policy targets all sites in the tenant or only selected sites. Accepted values are "AllSites" and "SelectedSites". If "SelectedSites" is chosen, you must add at least one site using `Add-SPOSiteToFileArchivePolicy` before the policy can be activated.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: AllSites, SelectedSites
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+This cmdlet is part of the File Archive Policies feature which is currently in preview. The policy is created in an Inactive state. Use `Set-SPOFileArchivePolicy` with `-State Active` to activate it.
+
+## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
@@ -1,14 +1,20 @@
 ---
 external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/new-spofilearchivepolicy
+applicable: SharePoint Online
+title: New-SPOFileArchivePolicy
 schema: 2.0.0
+author: HectorRMota
+ms.author: hemota
+ms.reviewer:
 ---
 
 # New-SPOFileArchivePolicy
 
 ## SYNOPSIS
-Creates a new File Archive Policy for the tenant.
+
+Creates a new file archive policy for the tenant.
 
 ## SYNTAX
 
@@ -18,37 +24,43 @@ New-SPOFileArchivePolicy [-Name <String>] -PolicyType <String> [-LastAccessDateC
 ```
 
 ## DESCRIPTION
-The `New-SPOFileArchivePolicy` cmdlet creates a new File Archive Policy for the connected SharePoint Online tenant. A File Archive Policy defines the criteria under which files are automatically archived based on their last access date. The policy is created in an Inactive state and must be activated using `Set-SPOFileArchivePolicy` before it takes effect.
 
-You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+This cmdlet creates a new file archive policy for the connected SharePoint Online tenant. A file archive policy defines the criteria under which files are automatically archived based on their last access date. The policy is created in an Inactive state and must be activated using `Set-SPOFileArchivePolicy` before it takes effect.
+
+> [!NOTE]
+> This cmdlet is part of the file archive policies feature which is currently in preview.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-PS C:\> New-SPOFileArchivePolicy -PolicyType "AllSites" -Name "ArchiveAll"
+New-SPOFileArchivePolicy -PolicyType "AllSites" -Name "ArchiveAll"
 ```
 
-Creates a new File Archive Policy named "ArchiveAll" that targets all sites in the tenant, using the default last access date criteria of 24 months.
+Creates a new file archive policy named "ArchiveAll" that targets all sites in the tenant, using the default last access date criteria of 24 months.
 
 ### Example 2
+
 ```powershell
-PS C:\> New-SPOFileArchivePolicy -PolicyType "SelectedSites" -Name "ArchiveMarketing" -LastAccessDateCriteria 12 -FileTypeCriteria ".docx", ".pptx", ".xlsx"
+New-SPOFileArchivePolicy -PolicyType "SelectedSites" -Name "ArchiveMarketing" -LastAccessDateCriteria 12 -FileTypeCriteria ".docx", ".pptx", ".xlsx"
 ```
 
-Creates a new File Archive Policy named "ArchiveMarketing" that targets selected sites, archives files not accessed in the last 12 months, and only applies to .docx, .pptx, and .xlsx file types.
+Creates a new file archive policy named "ArchiveMarketing" that targets selected sites, archives files not accessed in the last 12 months, and only applies to .docx, .pptx, and .xlsx file types.
 
 ### Example 3
+
 ```powershell
-PS C:\> New-SPOFileArchivePolicy -PolicyType "AllSites" -IsWhatIfMode $true
+New-SPOFileArchivePolicy -PolicyType "AllSites" -IsWhatIfMode $true
 ```
 
-Creates a new File Archive Policy in WhatIf mode. When the policy runs, it will report which files would be archived without actually archiving them.
+Creates a new file archive policy in `WhatIf` mode. When the policy runs, it will report which files would be archived without actually archiving them.
 
 ## PARAMETERS
 
 ### -FileTypeCriteria
-Specifies an array of file extensions to include in the policy. Only files matching the specified extensions will be considered for archiving. Use the dot-prefixed format (e.g., ".docx", ".pdf"). If not specified, all file types are included.
+
+Specifies an array of file extensions to include in the policy. Only files matching the specified extensions will be considered for archiving. Use the dot-prefixed format. If not specified, all file types are included.
 
 ```yaml
 Type: String[]
@@ -63,7 +75,8 @@ Accept wildcard characters: False
 ```
 
 ### -IsWhatIfMode
-Specifies whether the policy runs in WhatIf mode. When set to `$true`, the policy will evaluate which files meet the archiving criteria and report the results, but will not actually archive any files. When set to `$false` or not specified, the policy archives files normally when active.
+
+Specifies whether the policy runs in `WhatIf` mode. When set to `$true`, the policy will evaluate which files meet the archiving criteria and report the results, but will not actually archive any files. When set to `$false` or not specified, the policy archives files normally when active.
 
 ```yaml
 Type: Boolean
@@ -78,7 +91,8 @@ Accept wildcard characters: False
 ```
 
 ### -LastAccessDateCriteria
-Specifies the number of months since a file was last accessed before it becomes eligible for archiving. Valid values range from 6 to 48. The default value is 24 months. Note: the last access date is accurate starting July 2025.  Dates before that may be missing access signals from some clients.  For critical data, ensure your criteria doesn't archive based on last access dates before July 2025. 
+
+Specifies the number of months since a file was last accessed before it becomes eligible for archiving. Valid values range from 6 to 48. The default value is 24 months. Note: the last access date is accurate starting July 2025. Dates before that may be missing access signals from some clients. For critical data, ensure your criteria doesn't archive based on last access dates before July 2025.
 
 ```yaml
 Type: Int32
@@ -93,6 +107,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies a display name for the policy. If not specified, defaults to "MyPolicy".
 
 ```yaml
@@ -108,6 +123,7 @@ Accept wildcard characters: False
 ```
 
 ### -PolicyType
+
 Specifies whether the policy targets all sites in the tenant or only selected sites. Accepted values are "AllSites" and "SelectedSites". If "SelectedSites" is chosen, you must add at least one site using `Add-SPOSiteToFileArchivePolicy` before the policy can be activated.
 
 ```yaml
@@ -124,7 +140,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -133,8 +150,9 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
+
 ## NOTES
 
-This cmdlet is part of the File Archive Policies feature which is currently in preview. The policy is created in an Inactive state. Use `Set-SPOFileArchivePolicy` with `-State Active` to activate it.
+The policy is created in an Inactive state. Use `Set-SPOFileArchivePolicy` with `-State Active` to activate it.
 
 ## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
@@ -157,3 +157,17 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## NOTES
 
 ## RELATED LINKS
+
+[Add-SPOSiteToFileArchivePolicy](Add-SPOSiteToFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicy](Get-SPOFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicyReport](Get-SPOFileArchivePolicyReport.md)
+
+[Get-SPOFileArchivePolicySites](Get-SPOFileArchivePolicySites.md)
+
+[Remove-SPOFileArchivePolicy](Remove-SPOFileArchivePolicy.md)
+
+[Remove-SPOSiteToFileArchivePolicy](Remove-SPOSiteToFileArchivePolicy.md)
+
+[Set-SPOFileArchivePolicy](Set-SPOFileArchivePolicy.md)

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
@@ -25,7 +25,7 @@ New-SPOFileArchivePolicy [-Name <String>] -PolicyType <String> [-LastAccessDateC
 
 ## DESCRIPTION
 
-This cmdlet creates a new file archive policy for the connected SharePoint Online tenant. A file archive policy defines the criteria under which files are automatically archived based on their last access date. The policy is created in an Inactive state and must be activated using `Set-SPOFileArchivePolicy` before it takes effect.
+This cmdlet creates a new file archive policy for the connected SharePoint Online tenant. A file archive policy defines the criteria under which files are automatically archived based on their last access date. The policy is created in an Inactive state and must be activated using `Set-SPOFileArchivePolicy` with `-State Active` before it takes effect.
 
 > [!NOTE]
 > This cmdlet is part of the file archive policies feature which is currently in preview.
@@ -92,7 +92,10 @@ Accept wildcard characters: False
 
 ### -LastAccessDateCriteria
 
-Specifies the number of months since a file was last accessed before it becomes eligible for archiving. Valid values range from 6 to 48. The default value is 24 months. Note: the last access date is accurate starting July 2025. Dates before that may be missing access signals from some clients. For critical data, ensure your criteria doesn't archive based on last access dates before July 2025.
+Specifies the number of months since a file was last accessed before it becomes eligible for archiving. Valid values range from 6 to 48. The default value is 24 months.
+
+> [!IMPORTANT]
+> The last access date is accurate starting July 2025. Dates before that may be missing access signals from some clients. For critical data, ensure your criteria doesn't archive based on last access dates before July 2025.
 
 ```yaml
 Type: Int32
@@ -124,7 +127,7 @@ Accept wildcard characters: False
 
 ### -PolicyType
 
-Specifies whether the policy targets all sites in the tenant or only selected sites. Accepted values are "AllSites" and "SelectedSites". If "SelectedSites" is chosen, you must add at least one site using `Add-SPOSiteToFileArchivePolicy` before the policy can be activated.
+Specifies whether the policy targets all sites in the tenant or only selected sites. Accepted values are `AllSites` and `SelectedSites`. If `SelectedSites` is chosen, you must add at least one site using `Add-SPOSiteToFileArchivePolicy` before the policy can be activated.
 
 ```yaml
 Type: String
@@ -152,7 +155,5 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ### System.Object
 
 ## NOTES
-
-The policy is created in an Inactive state. Use `Set-SPOFileArchivePolicy` with `-State Active` to activate it.
 
 ## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
@@ -19,7 +19,7 @@ Creates a new file archive policy for the tenant.
 ## SYNTAX
 
 ```
-New-SPOFileArchivePolicy [-Name <String>] -PolicyType <String> [-LastAccessDateCriteria <Int32>]
+New-SPOFileArchivePolicy [-Name <String>] -PolicyType <SPOFileArchivePolicyType> [-LastAccessDateCriteria <Int32>]
  [-FileTypeCriteria <String[]>] [-IsWhatIfMode <Boolean>] [<CommonParameters>]
 ```
 
@@ -130,7 +130,7 @@ Accept wildcard characters: False
 Specifies whether the policy targets all sites in the tenant or only selected sites. Accepted values are `AllSites` and `SelectedSites`. If `SelectedSites` is chosen, you must add at least one site using `Add-SPOSiteToFileArchivePolicy` before the policy can be activated.
 
 ```yaml
-Type: String
+Type: SPOFileArchivePolicyType
 Parameter Sets: (All)
 Aliases:
 Accepted values: AllSites, SelectedSites

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOFileArchivePolicy.md
@@ -1,0 +1,117 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Remove-SPOFileArchivePolicy
+
+## SYNOPSIS
+Removes (soft-deletes) a File Archive Policy.
+
+## SYNTAX
+
+```
+Remove-SPOFileArchivePolicy -PolicyId <Guid> [-Force] [-WhatIf] [-Confirm] [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `Remove-SPOFileArchivePolicy` cmdlet soft-deletes a File Archive Policy by setting its state to Deleted. The policy will no longer run after being removed. By default, the cmdlet prompts for confirmation before proceeding. Use the `-Force` parameter to bypass the confirmation prompt.
+
+You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Remove-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+```
+
+Removes the specified File Archive Policy after prompting for confirmation.
+
+### Example 2
+```powershell
+PS C:\> Remove-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Force
+```
+
+Removes the specified File Archive Policy without prompting for confirmation.
+
+## PARAMETERS
+
+### -Confirm
+Prompts you for confirmation before running the cmdlet.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: cf
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+Bypasses the confirmation prompt and removes the policy immediately.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PolicyId
+Specifies the unique identifier (GUID) of the policy to remove.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WhatIf
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: wi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+This cmdlet is part of the File Archive Policies feature which is currently in preview.
+
+## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOFileArchivePolicy.md
@@ -129,3 +129,17 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## NOTES
 
 ## RELATED LINKS
+
+[Add-SPOSiteToFileArchivePolicy](Add-SPOSiteToFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicy](Get-SPOFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicyReport](Get-SPOFileArchivePolicyReport.md)
+
+[Get-SPOFileArchivePolicySites](Get-SPOFileArchivePolicySites.md)
+
+[New-SPOFileArchivePolicy](New-SPOFileArchivePolicy.md)
+
+[Remove-SPOSiteToFileArchivePolicy](Remove-SPOSiteToFileArchivePolicy.md)
+
+[Set-SPOFileArchivePolicy](Set-SPOFileArchivePolicy.md)

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOFileArchivePolicy.md
@@ -1,14 +1,20 @@
 ---
 external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/remove-spofilearchivepolicy
+applicable: SharePoint Online
+title: Remove-SPOFileArchivePolicy
 schema: 2.0.0
+author: HectorRMota
+ms.author: hemota
+ms.reviewer:
 ---
 
 # Remove-SPOFileArchivePolicy
 
 ## SYNOPSIS
-Removes (soft-deletes) a File Archive Policy.
+
+Removes (soft-deletes) a file archive policy.
 
 ## SYNTAX
 
@@ -17,29 +23,34 @@ Remove-SPOFileArchivePolicy -PolicyId <Guid> [-Force] [-WhatIf] [-Confirm] [<Com
 ```
 
 ## DESCRIPTION
-The `Remove-SPOFileArchivePolicy` cmdlet soft-deletes a File Archive Policy by setting its state to Deleted. The policy will no longer run after being removed. By default, the cmdlet prompts for confirmation before proceeding. Use the `-Force` parameter to bypass the confirmation prompt.
 
-You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+This cmdlet soft-deletes a file archive policy by setting its state to Deleted. The policy will no longer run after being removed. By default, the cmdlet prompts for confirmation before proceeding. Use the `-Force` parameter to bypass the confirmation prompt.
+
+> [!NOTE]
+> This cmdlet is part of the file archive policies feature which is currently in preview.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-PS C:\> Remove-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+Remove-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 ```
 
-Removes the specified File Archive Policy after prompting for confirmation.
+Removes the specified file archive policy after prompting for confirmation.
 
 ### Example 2
+
 ```powershell
-PS C:\> Remove-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Force
+Remove-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Force
 ```
 
-Removes the specified File Archive Policy without prompting for confirmation.
+Removes the specified file archive policy without prompting for confirmation.
 
 ## PARAMETERS
 
 ### -Confirm
+
 Prompts you for confirmation before running the cmdlet.
 
 ```yaml
@@ -55,6 +66,7 @@ Accept wildcard characters: False
 ```
 
 ### -Force
+
 Bypasses the confirmation prompt and removes the policy immediately.
 
 ```yaml
@@ -70,6 +82,7 @@ Accept wildcard characters: False
 ```
 
 ### -PolicyId
+
 Specifies the unique identifier (GUID) of the policy to remove.
 
 ```yaml
@@ -85,6 +98,7 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
+
 Shows what would happen if the cmdlet runs.
 The cmdlet is not run.
 
@@ -101,7 +115,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -110,8 +125,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-## NOTES
 
-This cmdlet is part of the File Archive Policies feature which is currently in preview.
+## NOTES
 
 ## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOSiteToFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOSiteToFileArchivePolicy.md
@@ -1,0 +1,79 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Remove-SPOSiteToFileArchivePolicy
+
+## SYNOPSIS
+Removes a site from a File Archive Policy.
+
+## SYNTAX
+
+```
+Remove-SPOSiteToFileArchivePolicy -PolicyId <Guid> -Site <SpoSitePipeBind> [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `Remove-SPOSiteToFileArchivePolicy` cmdlet removes a site from an existing File Archive Policy. The site will no longer be included in future policy runs.
+
+You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Remove-SPOSiteToFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Site "https://contoso.sharepoint.com/sites/marketing"
+```
+
+Removes the marketing site from the specified File Archive Policy.
+
+## PARAMETERS
+
+### -PolicyId
+Specifies the unique identifier (GUID) of the policy to remove the site from.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Site
+Specifies the URL of the site to remove from the policy (e.g., "https://contoso.sharepoint.com/sites/marketing").
+
+```yaml
+Type: SpoSitePipeBind
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+This cmdlet is part of the File Archive Policies feature which is currently in preview.
+
+## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOSiteToFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOSiteToFileArchivePolicy.md
@@ -1,14 +1,20 @@
 ---
 external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/remove-spositetofilearchivepolicy
+applicable: SharePoint Online
+title: Remove-SPOSiteToFileArchivePolicy
 schema: 2.0.0
+author: HectorRMota
+ms.author: hemota
+ms.reviewer:
 ---
 
 # Remove-SPOSiteToFileArchivePolicy
 
 ## SYNOPSIS
-Removes a site from a File Archive Policy.
+
+Removes a site from a file archive policy.
 
 ## SYNTAX
 
@@ -17,22 +23,26 @@ Remove-SPOSiteToFileArchivePolicy -PolicyId <Guid> -Site <SpoSitePipeBind> [<Com
 ```
 
 ## DESCRIPTION
-The `Remove-SPOSiteToFileArchivePolicy` cmdlet removes a site from an existing File Archive Policy. The site will no longer be included in future policy runs.
 
-You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+This cmdlet removes a site from an existing file archive policy. The site will no longer be included in future policy runs.
+
+> [!NOTE]
+> This cmdlet is part of the file archive policies feature which is currently in preview.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-PS C:\> Remove-SPOSiteToFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Site "https://contoso.sharepoint.com/sites/marketing"
+Remove-SPOSiteToFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Site "https://contoso.sharepoint.com/sites/marketing"
 ```
 
-Removes the marketing site from the specified File Archive Policy.
+Removes the marketing site from the specified file archive policy.
 
 ## PARAMETERS
 
 ### -PolicyId
+
 Specifies the unique identifier (GUID) of the policy to remove the site from.
 
 ```yaml
@@ -48,7 +58,8 @@ Accept wildcard characters: False
 ```
 
 ### -Site
-Specifies the URL of the site to remove from the policy (e.g., "https://contoso.sharepoint.com/sites/marketing").
+
+Specifies the URL of the site to remove from the policy.
 
 ```yaml
 Type: SpoSitePipeBind
@@ -63,7 +74,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -72,8 +84,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-## NOTES
 
-This cmdlet is part of the File Archive Policies feature which is currently in preview.
+## NOTES
 
 ## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOSiteToFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOSiteToFileArchivePolicy.md
@@ -88,3 +88,17 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## NOTES
 
 ## RELATED LINKS
+
+[Add-SPOSiteToFileArchivePolicy](Add-SPOSiteToFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicy](Get-SPOFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicyReport](Get-SPOFileArchivePolicyReport.md)
+
+[Get-SPOFileArchivePolicySites](Get-SPOFileArchivePolicySites.md)
+
+[New-SPOFileArchivePolicy](New-SPOFileArchivePolicy.md)
+
+[Remove-SPOFileArchivePolicy](Remove-SPOFileArchivePolicy.md)
+
+[Set-SPOFileArchivePolicy](Set-SPOFileArchivePolicy.md)

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
@@ -26,7 +26,7 @@ Set-SPOFileArchivePolicy -PolicyId <Guid> [-Name <String>] [-PolicyType <String>
 
 ## DESCRIPTION
 
-This cmdlet updates the properties of an existing file archive policy. Only the parameters that are specified will be updated; all other properties remain unchanged. You cannot set the State to "Active" unless the PolicyType is "AllSites" or at least one site has been added to the policy using `Add-SPOSiteToFileArchivePolicy`.
+This cmdlet updates the properties of an existing file archive policy. Only the parameters that are specified will be updated; all other properties remain unchanged. You cannot set the State to `Active` unless the PolicyType is `AllSites` or at least one site has been added to the policy using `Add-SPOSiteToFileArchivePolicy`.
 
 > [!NOTE]
 > This cmdlet is part of the file archive policies feature which is currently in preview.
@@ -141,7 +141,7 @@ Accept wildcard characters: False
 
 ### -PolicyType
 
-Specifies the updated policy type. Accepted values are "AllSites" (targets all sites in the tenant) and "SelectedSites" (targets only sites explicitly added to the policy).
+Specifies the updated policy type. Accepted values are `AllSites` (targets all sites in the tenant) and `SelectedSites` (targets only sites explicitly added to the policy).
 
 ```yaml
 Type: String
@@ -158,7 +158,7 @@ Accept wildcard characters: False
 
 ### -State
 
-Specifies the updated state of the policy. Accepted values are "Active" and "Inactive". A policy cannot be set to "Active" unless its PolicyType is "AllSites" or at least one site has been added to it.
+Specifies the updated state of the policy. Accepted values are `Active` and `Inactive`. A policy cannot be set to `Active` unless its PolicyType is `AllSites` or at least one site has been added to it.
 
 ```yaml
 Type: String

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
@@ -1,14 +1,20 @@
 ---
 external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
 Module Name: Microsoft.Online.SharePoint.PowerShell
-online version:
+online version: https://learn.microsoft.com/powershell/module/microsoft.online.sharepoint.powershell/set-spofilearchivepolicy
+applicable: SharePoint Online
+title: Set-SPOFileArchivePolicy
 schema: 2.0.0
+author: HectorRMota
+ms.author: hemota
+ms.reviewer:
 ---
 
 # Set-SPOFileArchivePolicy
 
 ## SYNOPSIS
-Updates an existing File Archive Policy.
+
+Updates an existing file archive policy.
 
 ## SYNTAX
 
@@ -19,37 +25,43 @@ Set-SPOFileArchivePolicy -PolicyId <Guid> [-Name <String>] [-PolicyType <String>
 ```
 
 ## DESCRIPTION
-The `Set-SPOFileArchivePolicy` cmdlet updates the properties of an existing File Archive Policy. Only the parameters that are specified will be updated; all other properties remain unchanged. You cannot set the State to "Active" unless the PolicyType is "AllSites" or at least one site has been added to the policy using `Add-SPOSiteToFileArchivePolicy`.
 
-You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+This cmdlet updates the properties of an existing file archive policy. Only the parameters that are specified will be updated; all other properties remain unchanged. You cannot set the State to "Active" unless the PolicyType is "AllSites" or at least one site has been added to the policy using `Add-SPOSiteToFileArchivePolicy`.
+
+> [!NOTE]
+> This cmdlet is part of the file archive policies feature which is currently in preview.
 
 ## EXAMPLES
 
 ### Example 1
+
 ```powershell
-PS C:\> Set-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -State "Active"
+Set-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -State "Active"
 ```
 
-Activates the specified File Archive Policy.
+Activates the specified file archive policy.
 
 ### Example 2
+
 ```powershell
-PS C:\> Set-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Name "Updated Policy Name" -LastAccessDateCriteria 12
+Set-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Name "Updated Policy Name" -LastAccessDateCriteria 12
 ```
 
 Updates the display name and changes the last access date criteria to 12 months for the specified policy.
 
 ### Example 3
+
 ```powershell
-PS C:\> Set-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -IsWhatIfMode $true
+Set-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -IsWhatIfMode $true
 ```
 
-Enables WhatIf mode on the specified policy. Future policy runs will report eligible files without archiving them.
+Enables `WhatIf` mode on the specified policy. Future policy runs will report eligible files without archiving them.
 
 ## PARAMETERS
 
 ### -FileTypeCriteria
-Specifies an updated array of file extensions to include in the policy. Only files matching the specified extensions will be considered for archiving. Use the dot-prefixed format (e.g., ".docx", ".pdf"). Set to `$null` to include all file types.
+
+Specifies an updated array of file extensions to include in the policy. Only files matching the specified extensions will be considered for archiving. Use the dot-prefixed format. Set to `$null` to include all file types.
 
 ```yaml
 Type: String[]
@@ -64,7 +76,8 @@ Accept wildcard characters: False
 ```
 
 ### -IsWhatIfMode
-Specifies whether the policy runs in WhatIf mode. When set to `$true`, the policy will evaluate which files meet the archiving criteria and report the results, but will not actually archive any files. When set to `$false`, the policy archives files normally when active.
+
+Specifies whether the policy runs in `WhatIf` mode. When set to `$true`, the policy will evaluate which files meet the archiving criteria and report the results, but will not actually archive any files. When set to `$false`, the policy archives files normally when active.
 
 ```yaml
 Type: Boolean
@@ -79,6 +92,7 @@ Accept wildcard characters: False
 ```
 
 ### -LastAccessDateCriteria
+
 Specifies the updated number of months since a file was last accessed before it becomes eligible for archiving. Valid values range from 6 to 48.
 
 ```yaml
@@ -94,6 +108,7 @@ Accept wildcard characters: False
 ```
 
 ### -Name
+
 Specifies an updated display name for the policy.
 
 ```yaml
@@ -109,6 +124,7 @@ Accept wildcard characters: False
 ```
 
 ### -PolicyId
+
 Specifies the unique identifier (GUID) of the policy to update.
 
 ```yaml
@@ -124,6 +140,7 @@ Accept wildcard characters: False
 ```
 
 ### -PolicyType
+
 Specifies the updated policy type. Accepted values are "AllSites" (targets all sites in the tenant) and "SelectedSites" (targets only sites explicitly added to the policy).
 
 ```yaml
@@ -140,6 +157,7 @@ Accept wildcard characters: False
 ```
 
 ### -State
+
 Specifies the updated state of the policy. Accepted values are "Active" and "Inactive". A policy cannot be set to "Active" unless its PolicyType is "AllSites" or at least one site has been added to it.
 
 ```yaml
@@ -156,7 +174,8 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVariable`, `-InformationAction`, `-InformationVariable`, `-OutVariable`, `-OutBuffer`, `-PipelineVariable`, `-ProgressAction`, `-Verbose`, `-WarningAction`, and `-WarningVariable`. For more information, see [about_CommonParameters](/powershell/module/microsoft.powershell.core/about/about_commonparameters).
 
 ## INPUTS
 
@@ -165,8 +184,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### System.Object
-## NOTES
 
-This cmdlet is part of the File Archive Policies feature which is currently in preview.
+## NOTES
 
 ## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
@@ -1,0 +1,172 @@
+---
+external help file: Microsoft.Online.SharePoint.PowerShell.dll-Help.xml
+Module Name: Microsoft.Online.SharePoint.PowerShell
+online version:
+schema: 2.0.0
+---
+
+# Set-SPOFileArchivePolicy
+
+## SYNOPSIS
+Updates an existing File Archive Policy.
+
+## SYNTAX
+
+```
+Set-SPOFileArchivePolicy -PolicyId <Guid> [-Name <String>] [-PolicyType <String>]
+ [-LastAccessDateCriteria <Int32>] [-FileTypeCriteria <String[]>] [-IsWhatIfMode <Boolean>] [-State <String>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+The `Set-SPOFileArchivePolicy` cmdlet updates the properties of an existing File Archive Policy. Only the parameters that are specified will be updated; all other properties remain unchanged. You cannot set the State to "Active" unless the PolicyType is "AllSites" or at least one site has been added to the policy using `Add-SPOSiteToFileArchivePolicy`.
+
+You must be a SharePoint Administrator or Global Administrator to run this cmdlet.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> Set-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -State "Active"
+```
+
+Activates the specified File Archive Policy.
+
+### Example 2
+```powershell
+PS C:\> Set-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Name "Updated Policy Name" -LastAccessDateCriteria 12
+```
+
+Updates the display name and changes the last access date criteria to 12 months for the specified policy.
+
+### Example 3
+```powershell
+PS C:\> Set-SPOFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -IsWhatIfMode $true
+```
+
+Enables WhatIf mode on the specified policy. Future policy runs will report eligible files without archiving them.
+
+## PARAMETERS
+
+### -FileTypeCriteria
+Specifies an updated array of file extensions to include in the policy. Only files matching the specified extensions will be considered for archiving. Use the dot-prefixed format (e.g., ".docx", ".pdf"). Set to `$null` to include all file types.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IsWhatIfMode
+Specifies whether the policy runs in WhatIf mode. When set to `$true`, the policy will evaluate which files meet the archiving criteria and report the results, but will not actually archive any files. When set to `$false`, the policy archives files normally when active.
+
+```yaml
+Type: Boolean
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LastAccessDateCriteria
+Specifies the updated number of months since a file was last accessed before it becomes eligible for archiving. Valid values range from 6 to 48.
+
+```yaml
+Type: Int32
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+Specifies an updated display name for the policy.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PolicyId
+Specifies the unique identifier (GUID) of the policy to update.
+
+```yaml
+Type: Guid
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PolicyType
+Specifies the updated policy type. Accepted values are "AllSites" (targets all sites in the tenant) and "SelectedSites" (targets only sites explicitly added to the policy).
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: AllSites, SelectedSites
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -State
+Specifies the updated state of the policy. Accepted values are "Active" and "Inactive". A policy cannot be set to "Active" unless its PolicyType is "AllSites" or at least one site has been added to it.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+Accepted values: Active, Inactive
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### None
+
+## OUTPUTS
+
+### System.Object
+## NOTES
+
+This cmdlet is part of the File Archive Policies feature which is currently in preview.
+
+## RELATED LINKS

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
@@ -19,8 +19,8 @@ Updates an existing file archive policy.
 ## SYNTAX
 
 ```
-Set-SPOFileArchivePolicy -PolicyId <Guid> [-Name <String>] [-PolicyType <String>]
- [-LastAccessDateCriteria <Int32>] [-FileTypeCriteria <String[]>] [-IsWhatIfMode <Boolean>] [-State <String>]
+Set-SPOFileArchivePolicy -PolicyId <Guid> [-Name <String>] [-PolicyType <SPOFileArchivePolicyType>]
+ [-LastAccessDateCriteria <Int32>] [-FileTypeCriteria <String[]>] [-IsWhatIfMode <Boolean>] [-State <SPOFileArchivePolicyState>]
  [<CommonParameters>]
 ```
 
@@ -144,7 +144,7 @@ Accept wildcard characters: False
 Specifies the updated policy type. Accepted values are `AllSites` (targets all sites in the tenant) and `SelectedSites` (targets only sites explicitly added to the policy).
 
 ```yaml
-Type: String
+Type: SPOFileArchivePolicyType
 Parameter Sets: (All)
 Aliases:
 Accepted values: AllSites, SelectedSites
@@ -161,7 +161,7 @@ Accept wildcard characters: False
 Specifies the updated state of the policy. Accepted values are `Active` and `Inactive`. A policy cannot be set to `Active` unless its PolicyType is `AllSites` or at least one site has been added to it.
 
 ```yaml
-Type: String
+Type: SPOFileArchivePolicyState
 Parameter Sets: (All)
 Aliases:
 Accepted values: Active, Inactive

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
@@ -188,3 +188,17 @@ This cmdlet supports the common parameters: `-Debug`, `-ErrorAction`, `-ErrorVar
 ## NOTES
 
 ## RELATED LINKS
+
+[Add-SPOSiteToFileArchivePolicy](Add-SPOSiteToFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicy](Get-SPOFileArchivePolicy.md)
+
+[Get-SPOFileArchivePolicyReport](Get-SPOFileArchivePolicyReport.md)
+
+[Get-SPOFileArchivePolicySites](Get-SPOFileArchivePolicySites.md)
+
+[New-SPOFileArchivePolicy](New-SPOFileArchivePolicy.md)
+
+[Remove-SPOFileArchivePolicy](Remove-SPOFileArchivePolicy.md)
+
+[Remove-SPOSiteToFileArchivePolicy](Remove-SPOSiteToFileArchivePolicy.md)


### PR DESCRIPTION
 ## Summary
 
 This PR adds reference documentation for the SharePoint Online File Archive Policy cmdlets. These cmdlets allow SharePoint and Global Administrators to create, configure, monitor, and manage file archive policies that automatically archive files based on criteria such as last access date and file type.
 
 ## New cmdlets documented
 
 | Cmdlet | Description |
 |--------|-------------|
 | `New-SPOFileArchivePolicy` | Creates a new File Archive Policy for the tenant |
 | `Get-SPOFileArchivePolicy` | Gets one or all File Archive Policies for the tenant |
 | `Get-SPOFileArchivePolicyReport` | Gets the report for a File Archive Policy |
 | `Get-SPOFileArchivePolicySites` | Gets the sites associated with a File Archive Policy |
 | `Set-SPOFileArchivePolicy` | Updates an existing File Archive Policy |
 | `Remove-SPOFileArchivePolicy` | Removes a File Archive Policy |
 | `Add-SPOSiteToFileArchivePolicy` | Adds a site to a File Archive Policy |
 | `Remove-SPOSiteToFileArchivePolicy` | Removes a site from a File Archive Policy |
 
 ## Details
 
 - Module: `Microsoft.Online.SharePoint.PowerShell`
 - All cmdlets require SharePoint Administrator or Global Administrator role