### PR TITLE
Add PolicyName parameter to Start-SPORestrictedAccessForSitesInsights

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Start-SPORestrictedAccessForSitesInsights.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Start-SPORestrictedAccessForSitesInsights.md
@@ -20,7 +20,7 @@ This cmdlet enables administrator to trigger the build of a new restricted acces
 ## SYNTAX
 
 ```
-Start-SPORestrictedAccessForSitesInsights [-RACProtectedSites] [-ActionsBlockedByPolicy] [-Force] [-WhatIf]
+Start-SPORestrictedAccessForSitesInsights [-RACProtectedSites] [-PolicyName <String>][-ActionsBlockedByPolicy] [-Force] [-WhatIf]
  [-Confirm] [<CommonParameters>]
 ```
 
@@ -101,6 +101,23 @@ Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -PolicyName
+
+> Applicable: SharePoint Online
+
+It is an optional parameter, used together with -ActionsBlockedByPolicy, that scopes the report to a single policy.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
 
 ### -Confirm
 Prompts you for confirmation before running the cmdlet.

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Start-SPORestrictedAccessForSitesInsights.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Start-SPORestrictedAccessForSitesInsights.md
@@ -15,7 +15,7 @@ manager:
 
 ## SYNOPSIS
 
-This cmdlet enables administrator to trigger the build of a new restricted access control insights report for the data from last 28 days.
+This cmdlet starts the generation of a new restricted access control insights report based on data from the previous 28 days.
 
 ## SYNTAX
 
@@ -106,7 +106,7 @@ Accept wildcard characters: False
 
 > Applicable: SharePoint Online
 
-It is an optional parameter, used together with -ActionsBlockedByPolicy, that scopes the report to a single policy.
+It is an optional parameter, used together with `-ActionsBlockedByPolicy`, that scopes the report to a single policy.
 
 ```yaml
 Type: String

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Start-SPORestrictedAccessForSitesInsights.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Start-SPORestrictedAccessForSitesInsights.md
@@ -20,13 +20,13 @@ This cmdlet enables administrator to trigger the build of a new restricted acces
 ## SYNTAX
 
 ```
-Start-SPORestrictedAccessForSitesInsights [-RACProtectedSites] [-PolicyName <String>][-ActionsBlockedByPolicy] [-Force] [-WhatIf]
- [-Confirm] [<CommonParameters>]
+Start-SPORestrictedAccessForSitesInsights [-RACProtectedSites] [-ActionsBlockedByPolicy] [-Force]
+ [-PolicyName <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-After this cmdlet is executed, the restricted access control insights report generation request is initiated for the requested report subtype.                               |
+ This cmdlet enables administrator to trigger the build of a new restricted access control insights report for the data from last 28 days.
 
 ## EXAMPLES
 
@@ -118,6 +118,7 @@ Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
+```
 
 ### -Confirm
 Prompts you for confirmation before running the cmdlet.


### PR DESCRIPTION
 Documents the new -PolicyName parameter on Start-SPORestrictedAccessForSitesInsights, used to scope the Actions Blocked by Policy report to a single policy.