### PR TITLE
Document AI teammates site restriction

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOSite.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOSite.md
@@ -162,6 +162,14 @@ Get-SPOSite -Filter "Owner -like '$($userUPN)'"
 ```
 This example retrieves all sites filtering by the specified owner using a variable.
 
+### EXAMPLE 13
+
+```powershell
+Get-SPOSite -Identity https://contoso.sharepoint.com/sites/site1 | Select-Object Url, RestrictedForAITeammates
+```
+
+This example returns whether AI teammates are restricted from accessing the site. The property is currently under private preview. If the private preview isn't enabled for the tenant, `RestrictedForAITeammates` returns `False`.
+
 ## PARAMETERS
 
 ### -ArchiveStatus

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOSite.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOSite.md
@@ -62,6 +62,7 @@ Set-SPOSite [-Identity] <SpoSitePipeBind> [-Owner <String>] [-Title <String>] [-
  [-DefaultShareLinkScope <SharingScope>]
  [-DefaultShareLinkRole <SharingRole>] [-BlockGuestsAsSiteAdmin <SharingState>]
  [-RestrictContentOrgWideSearch <Boolean>] [-RestrictedContentDiscoveryforCopilotAndAgents <Boolean>]
+ [-RestrictedForAITeammates <Boolean>]
  [-RestrictedAccessControl <Boolean>] [-RestrictedAccessControlGroups <Guid[]>]
  [-ListsShowHeaderAndNavigation <Boolean>] [-HidePeoplePreviewingFiles <Boolean>]
  [-HidePeopleWhoHaveListsOpen <Boolean>] [-IsAuthoritative <Boolean>] [-AllowFileArchive <Boolean>]
@@ -384,6 +385,15 @@ Set-SPOSite -Identity https://contoso.sharepoint.com/sites/site1 -RemoveVersionE
 ```
 
 Example 24 removes the version history limit override for video and audio file types at the site level. The new document libraries will use this version setting.
+
+### Example 25
+
+```powershell
+Set-SPOSite -Identity https://contoso.sharepoint.com/sites/site1 -RestrictedForAITeammates $true
+Get-SPOSite -Identity https://contoso.sharepoint.com/sites/site1 | Select-Object Url, RestrictedForAITeammates
+```
+
+Example 25 restricts AI teammates from accessing the site and then returns the configured value. The policy is enforced at runtime and doesn't remove existing permissions.
 
 ## PARAMETERS
 
@@ -2095,6 +2105,26 @@ Accept wildcard characters: False
 ### -RestrictedContentDiscoveryforCopilotAndAgents
 
 Sets or updates the site setting to host Agents by activating or deactivating the Restricted Content Discovery (RCD) for Agents. *Currently under private preview.*
+
+```yaml
+Type: System.Boolean
+Parameter Sets: ParamSet1
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RestrictedForAITeammates
+
+> Applicable: SharePoint Online
+
+Specifies whether AI teammates are restricted from accessing the site. Set this parameter to `$true` to block AI teammates at runtime, or `$false` to remove the site restriction. Changing this setting doesn't remove existing permissions.
+
+This parameter is currently under private preview. If the private preview isn't enabled for the tenant, setting this parameter has no effect.
 
 ```yaml
 Type: System.Boolean


### PR DESCRIPTION
## Summary
- document `Set-SPOSite -RestrictedForAITeammates` syntax and behavior
- add `Set-SPOSite` and `Get-SPOSite` examples
- describe private-preview gating and runtime-only enforcement

## Publication timing
**Draft: do not merge until the private-preview rollout begins and the SharePoint Online Management Shell release containing this parameter is ready.**

## Validation
- `git diff --check` passes
- parameter metadata matches `System.Boolean` in `ParamSet1`