### PR TITLE
Update File Archive Policy cmdlets for OneDrive support

### DIFF
--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Add-SPOSiteToFileArchivePolicy.md
@@ -19,12 +19,18 @@ Adds a site to a file archive policy.
 ## SYNTAX
 
 ```
-Add-SPOSiteToFileArchivePolicy -PolicyId <Guid> -Site <SpoSitePipeBind> [<CommonParameters>]
+Add-SPOSiteToFileArchivePolicy -PolicyId <Guid> -Site <SpoSitePipeBind> [-Exclude] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-This cmdlet adds a site to an existing file archive policy that has a PolicyType of `SelectedSites`. The site must exist and be eligible for archiving. At least one site must be added before a `SelectedSites` policy can be activated.
+This cmdlet adds a site to an existing file archive policy, either as an inclusion or as an exclusion.
+
+By default, the site is added as an inclusion. Inclusions are only valid for a policy whose PolicyType is `SelectedSites`, and at least one site must be added before such a policy can be activated. Adding an inclusion to an `AllSites` or `AllODBSites` policy returns an error.
+
+When you use the `-Exclude` parameter, the site is added as an exclusion and is exempted from the policy when it runs. Exclusions are only valid for a policy whose PolicyType is `AllSites` or `AllODBSites`. Adding an exclusion to a `SelectedSites` policy returns an error.
+
+The site must exist and be eligible for archiving. A single policy can contain a maximum of 1,000 sites, counting inclusions and exclusions together.
 
 > [!NOTE]
 > This cmdlet is part of the file archive policies feature which is currently in preview.
@@ -37,9 +43,35 @@ This cmdlet adds a site to an existing file archive policy that has a PolicyType
 Add-SPOSiteToFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Site "https://contoso.sharepoint.com/sites/marketing"
 ```
 
-Adds the marketing site to the specified file archive policy.
+Adds the marketing site to the specified `SelectedSites` file archive policy, so that the policy applies to it.
+
+### Example 2
+
+```powershell
+Add-SPOSiteToFileArchivePolicy -PolicyId "a1b2c3d4-e5f6-7890-abcd-ef1234567890" -Site "https://contoso-my.sharepoint.com/personal/user_contoso_com" -Exclude
+```
+
+Adds a OneDrive for Business site to the specified `AllODBSites` policy as an exclusion, exempting it from archiving while the policy continues to apply to every other OneDrive site in the tenant.
 
 ## PARAMETERS
+
+### -Exclude
+
+Adds the site as an exclusion instead of an inclusion, exempting it from the policy when the policy runs.
+
+Use this parameter only with a policy whose PolicyType is `AllSites` or `AllODBSites`. Omit it when adding sites to a `SelectedSites` policy.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -PolicyId
 

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Get-SPOFileArchivePolicySites.md
@@ -24,7 +24,9 @@ Get-SPOFileArchivePolicySites -PolicyId <Guid> [<CommonParameters>]
 
 ## DESCRIPTION
 
-This cmdlet retrieves the list of sites that have been added to a file archive policy. This is applicable to policies with a PolicyType of `SelectedSites`.
+This cmdlet retrieves the list of sites that have been added to a file archive policy.
+
+For a policy with a PolicyType of `SelectedSites`, this returns the included sites that the policy applies to. For a policy with a PolicyType of `AllSites` or `AllODBSites`, this returns the excluded sites that are exempt from the policy.
 
 > [!NOTE]
 > This cmdlet is part of the file archive policies feature which is currently in preview.

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
@@ -20,12 +20,15 @@ Creates a new file archive policy for the tenant.
 
 ```
 New-SPOFileArchivePolicy [-Name <String>] -PolicyType <SPOFileArchivePolicyType> [-LastAccessDateCriteria <Int32>]
- [-FileTypeCriteria <String[]>] [-IsWhatIfMode <Boolean>] [<CommonParameters>]
+ [-FileTypeCriteria <String[]>] [-FileTypeExclusionCriteria <String[]>] [-IsWhatIfMode <Boolean>]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
 This cmdlet creates a new file archive policy for the connected SharePoint Online tenant. A file archive policy defines the criteria under which files are automatically archived based on their last access date. The policy is created in an Inactive state and must be activated using `Set-SPOFileArchivePolicy` with `-State Active` before it takes effect.
+
+Use `-PolicyType` to choose the scope of the policy: all SharePoint sites in the tenant (`AllSites`), all OneDrive for Business sites in the tenant (`AllODBSites`), or only the sites you explicitly add (`SelectedSites`).
 
 > [!NOTE]
 > This cmdlet is part of the file archive policies feature which is currently in preview.
@@ -43,12 +46,20 @@ Creates a new file archive policy named "ArchiveAll" that targets all sites in t
 ### Example 2
 
 ```powershell
-New-SPOFileArchivePolicy -PolicyType "SelectedSites" -Name "ArchiveMarketing" -LastAccessDateCriteria 12 -FileTypeCriteria ".docx", ".pptx", ".xlsx"
+New-SPOFileArchivePolicy -PolicyType "SelectedSites" -Name "ArchiveMarketing" -LastAccessDateCriteria 12
 ```
 
-Creates a new file archive policy named "ArchiveMarketing" that targets selected sites, archives files not accessed in the last 12 months, and only applies to .docx, .pptx, and .xlsx file types.
+Creates a new file archive policy named "ArchiveMarketing" that targets only the sites you add with `Add-SPOSiteToFileArchivePolicy`, and archives files not accessed in the last 12 months.
 
 ### Example 3
+
+```powershell
+New-SPOFileArchivePolicy -PolicyType "AllODBSites" -Name "ArchiveOneDrive"
+```
+
+Creates a new file archive policy named "ArchiveOneDrive" that targets all OneDrive for Business sites in the tenant. To exempt individual OneDrive sites, add them as exclusions with `Add-SPOSiteToFileArchivePolicy` and the `-Exclude` parameter.
+
+### Example 4
 
 ```powershell
 New-SPOFileArchivePolicy -PolicyType "AllSites" -IsWhatIfMode $true
@@ -60,7 +71,29 @@ Creates a new file archive policy in `WhatIf` mode. When the policy runs, it wil
 
 ### -FileTypeCriteria
 
-Specifies an array of file extensions to include in the policy. Only files matching the specified extensions will be considered for archiving. Use the dot-prefixed format. If not specified, all file types are included.
+Specifies an array of file extensions to include in the policy, in dot-prefixed format (for example, `.docx`). When omitted, all file types are included.
+
+> [!NOTE]
+> File type filtering isn't implemented in the current preview. Supplying this parameter returns the error "Updating file type criteria is not supported. Please remove and recreate the policy." Omit the parameter to create the policy with all file types included.
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileTypeExclusionCriteria
+
+Specifies an array of file extensions to exclude from the policy, in dot-prefixed format (for example, `.docx`). When omitted, no file types are excluded.
+
+> [!NOTE]
+> File type filtering isn't implemented in the current preview. Supplying this parameter returns the error "Updating file type exclusion criteria is not supported. Please remove and recreate the policy." Omit the parameter to create the policy with no file type exclusions.
 
 ```yaml
 Type: String[]
@@ -127,13 +160,19 @@ Accept wildcard characters: False
 
 ### -PolicyType
 
-Specifies whether the policy targets all sites in the tenant or only selected sites. Accepted values are `AllSites` and `SelectedSites`. If `SelectedSites` is chosen, you must add at least one site using `Add-SPOSiteToFileArchivePolicy` before the policy can be activated.
+Specifies the scope of the policy. Accepted values are:
+
+- `AllSites`: The policy applies to all SharePoint sites in the tenant.
+- `AllODBSites`: The policy applies to all OneDrive for Business sites in the tenant.
+- `SelectedSites`: The policy applies only to the sites you explicitly add to it.
+
+If you choose `SelectedSites`, you must add at least one site using `Add-SPOSiteToFileArchivePolicy` before the policy can be activated. If you choose `AllSites` or `AllODBSites`, you can optionally exempt individual sites by adding them with `Add-SPOSiteToFileArchivePolicy` and the `-Exclude` parameter.
 
 ```yaml
 Type: SPOFileArchivePolicyType
 Parameter Sets: (All)
 Aliases:
-Accepted values: AllSites, SelectedSites
+Accepted values: AllSites, SelectedSites, AllODBSites
 
 Required: True
 Position: Named

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/New-SPOFileArchivePolicy.md
@@ -71,10 +71,7 @@ Creates a new file archive policy in `WhatIf` mode. When the policy runs, it wil
 
 ### -FileTypeCriteria
 
-Specifies an array of file extensions to include in the policy, in dot-prefixed format (for example, `.docx`). When omitted, all file types are included.
-
-> [!NOTE]
-> File type filtering isn't implemented in the current preview. Supplying this parameter returns the error "Updating file type criteria is not supported. Please remove and recreate the policy." Omit the parameter to create the policy with all file types included.
+Specifies an array of file extensions to include in the policy, in dot-prefixed format (for example, `.docx`). Only files matching the specified extensions are considered for archiving. When omitted, all file types are included.
 
 ```yaml
 Type: String[]
@@ -90,10 +87,7 @@ Accept wildcard characters: False
 
 ### -FileTypeExclusionCriteria
 
-Specifies an array of file extensions to exclude from the policy, in dot-prefixed format (for example, `.docx`). When omitted, no file types are excluded.
-
-> [!NOTE]
-> File type filtering isn't implemented in the current preview. Supplying this parameter returns the error "Updating file type exclusion criteria is not supported. Please remove and recreate the policy." Omit the parameter to create the policy with no file type exclusions.
+Specifies an array of file extensions to exclude from the policy, in dot-prefixed format (for example, `.docx`). Files matching the specified extensions aren't archived. When omitted, no file types are excluded.
 
 ```yaml
 Type: String[]

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOSiteToFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Remove-SPOSiteToFileArchivePolicy.md
@@ -24,7 +24,11 @@ Remove-SPOSiteToFileArchivePolicy -PolicyId <Guid> -Site <SpoSitePipeBind> [<Com
 
 ## DESCRIPTION
 
-This cmdlet removes a site from an existing file archive policy. The site will no longer be included in future policy runs.
+This cmdlet removes a site from an existing file archive policy. It removes either an included site from a `SelectedSites` policy or an excluded site from an `AllSites` or `AllODBSites` policy.
+
+Removing an included site means the policy no longer applies to that site. Removing an excluded site means the site is no longer exempt, so the policy applies to it again on future runs.
+
+You can't remove the last remaining site from an active `SelectedSites` policy, because that would leave the policy active with no sites in scope. Set the policy to `Inactive` first, or add another site before removing this one.
 
 > [!NOTE]
 > This cmdlet is part of the file archive policies feature which is currently in preview.

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
@@ -20,13 +20,13 @@ Updates an existing file archive policy.
 
 ```
 Set-SPOFileArchivePolicy -PolicyId <Guid> [-Name <String>] [-PolicyType <SPOFileArchivePolicyType>]
- [-LastAccessDateCriteria <Int32>] [-FileTypeCriteria <String[]>] [-IsWhatIfMode <Boolean>] [-State <SPOFileArchivePolicyState>]
- [<CommonParameters>]
+ [-LastAccessDateCriteria <Int32>] [-FileTypeCriteria <String[]>] [-FileTypeExclusionCriteria <String[]>]
+ [-IsWhatIfMode <Boolean>] [-State <SPOFileArchivePolicyState>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 
-This cmdlet updates the properties of an existing file archive policy. Only the parameters that are specified will be updated; all other properties remain unchanged. You cannot set the State to `Active` unless the PolicyType is `AllSites` or at least one site has been added to the policy using `Add-SPOSiteToFileArchivePolicy`.
+This cmdlet updates the properties of an existing file archive policy. Only the parameters that are specified will be updated; all other properties remain unchanged. You cannot set the State to `Active` unless the PolicyType is `AllSites` or `AllODBSites`, or at least one site has been added to the policy using `Add-SPOSiteToFileArchivePolicy`.
 
 > [!NOTE]
 > This cmdlet is part of the file archive policies feature which is currently in preview.
@@ -61,7 +61,29 @@ Enables `WhatIf` mode on the specified policy. Future policy runs will report el
 
 ### -FileTypeCriteria
 
-Specifies an updated array of file extensions to include in the policy. Only files matching the specified extensions will be considered for archiving. Use the dot-prefixed format. Set to `$null` to include all file types.
+Specifies an updated array of file extensions to include in the policy, in dot-prefixed format (for example, `.docx`).
+
+> [!NOTE]
+> File type filtering isn't implemented in the current preview, and the inclusion list can't be changed after a policy is created. Supplying this parameter returns the error "Updating file type criteria is not supported. Please remove and recreate the policy to change this setting."
+
+```yaml
+Type: String[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileTypeExclusionCriteria
+
+Specifies an updated array of file extensions to exclude from the policy, in dot-prefixed format (for example, `.docx`).
+
+> [!NOTE]
+> File type filtering isn't implemented in the current preview, and the exclusion list can't be changed after a policy is created. Supplying this parameter returns the error "Updating file type exclusion criteria is not supported. Please remove and recreate the policy to change this setting."
 
 ```yaml
 Type: String[]
@@ -141,13 +163,17 @@ Accept wildcard characters: False
 
 ### -PolicyType
 
-Specifies the updated policy type. Accepted values are `AllSites` (targets all sites in the tenant) and `SelectedSites` (targets only sites explicitly added to the policy).
+Specifies the updated policy type. Accepted values are:
+
+- `AllSites`: The policy applies to all SharePoint sites in the tenant.
+- `AllODBSites`: The policy applies to all OneDrive for Business sites in the tenant.
+- `SelectedSites`: The policy applies only to the sites you explicitly add to it.
 
 ```yaml
 Type: SPOFileArchivePolicyType
 Parameter Sets: (All)
 Aliases:
-Accepted values: AllSites, SelectedSites
+Accepted values: AllSites, SelectedSites, AllODBSites
 
 Required: False
 Position: Named

--- a/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
+++ b/sharepoint/sharepoint-ps/Microsoft.Online.SharePoint.PowerShell/Set-SPOFileArchivePolicy.md
@@ -61,10 +61,7 @@ Enables `WhatIf` mode on the specified policy. Future policy runs will report el
 
 ### -FileTypeCriteria
 
-Specifies an updated array of file extensions to include in the policy, in dot-prefixed format (for example, `.docx`).
-
-> [!NOTE]
-> File type filtering isn't implemented in the current preview, and the inclusion list can't be changed after a policy is created. Supplying this parameter returns the error "Updating file type criteria is not supported. Please remove and recreate the policy to change this setting."
+Specifies an updated array of file extensions to include in the policy, in dot-prefixed format (for example, `.docx`). Only files matching the specified extensions are considered for archiving.
 
 ```yaml
 Type: String[]
@@ -80,10 +77,7 @@ Accept wildcard characters: False
 
 ### -FileTypeExclusionCriteria
 
-Specifies an updated array of file extensions to exclude from the policy, in dot-prefixed format (for example, `.docx`).
-
-> [!NOTE]
-> File type filtering isn't implemented in the current preview, and the exclusion list can't be changed after a policy is created. Supplying this parameter returns the error "Updating file type exclusion criteria is not supported. Please remove and recreate the policy to change this setting."
+Specifies an updated array of file extensions to exclude from the policy, in dot-prefixed format (for example, `.docx`). Files matching the specified extensions aren't archived.
 
 ```yaml
 Type: String[]


### PR DESCRIPTION
## Summary

Updates the File Archive Policy cmdlet reference to cover OneDrive for Business support and the site exclusion model, and corrects the guidance for the file type criteria parameters.

These cmdlets were first documented in #1181. This PR reflects subsequent changes to the cmdlet surface.

## Changes

**`Add-SPOSiteToFileArchivePolicy`**
- Documents the new `-Exclude` switch.
- Explains the two modes: inclusions are only valid for a `SelectedSites` policy, exclusions only for an `AllSites` or `AllODBSites` policy. Using the wrong one returns an error.
- Adds an exclusion example and notes the 1,000 site per policy limit.

**`New-SPOFileArchivePolicy`** and **`Set-SPOFileArchivePolicy`**
- Adds `AllODBSites` to the accepted values for `-PolicyType`, for policies that target all OneDrive for Business sites in the tenant.
- Documents the new `-FileTypeExclusionCriteria` parameter.
- `Set-SPOFileArchivePolicy`: corrects the activation rule, which also applies to `AllODBSites`.

**`Get-SPOFileArchivePolicySites`**
- Clarifies that the returned list is the included sites for a `SelectedSites` policy, and the excluded sites for an `AllSites` or `AllODBSites` policy.

**`Remove-SPOSiteToFileArchivePolicy`**
- Clarifies that it removes either an inclusion or an exclusion, and documents the guard that prevents removing the last site from an active `SelectedSites` policy.

## Corrects a published error

The existing `New-SPOFileArchivePolicy` Example 2 passes `-FileTypeCriteria`:

```powershell
New-SPOFileArchivePolicy -PolicyType "SelectedSites" -Name "ArchiveMarketing" -LastAccessDateCriteria 12 -FileTypeCriteria ".docx", ".pptx", ".xlsx"
```

File type filtering is not implemented in the current preview, and the service rejects any non-null value for this parameter with "Updating file type criteria is not supported." The example as published would fail for anyone who ran it, so it has been replaced with one that works.

Both `-FileTypeCriteria` and `-FileTypeExclusionCriteria` are now documented with a note describing the current behavior, so the newly added parameter isn't presented as functional either.

## Notes for reviewers

- The feature is in preview and gated behind a rollout flight, so none of this is customer-visible yet. Every affected topic already carries the existing preview note.
- No new topics are added and no files are renamed; all changes are to the five existing File Archive Policy topics. The module landing page needs no update, since the cmdlet summaries are unchanged.
